### PR TITLE
CEP-141: Add CEP limits in c84j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>co.macrometa</groupId>
 	<artifactId>c84j</artifactId>
-	<version>1.1.2-SNAPSHOT</version>
+	<version>1.1.3-SNAPSHOT</version>
 	<inceptionYear>2019</inceptionYear>
 	<packaging>jar</packaging>
 

--- a/src/main/java/com/c8db/entity/LimitsEntity.java
+++ b/src/main/java/com/c8db/entity/LimitsEntity.java
@@ -11,7 +11,8 @@ public class LimitsEntity implements Entity {
 	private Database database; 
 	private Streams streamsLocal, streamsGlobal;
 	private Compute compute;
-	 
+	private CEP cep;
+
 	private boolean defaultsEnabled;
 	
 	@Data	
@@ -55,5 +56,15 @@ public class LimitsEntity implements Entity {
 		private int maxRequestsMemoryMB;
 		private int maxSecretsCount;
 		private int maxServicesCount;
+	}
+
+	@Data
+	public static class CEP {
+		private int maxMemoryPerWorker;
+		private int maxPublishedWorkers;
+		private int maxWorkersMemorySizeMB;
+		private int maxWorkersCpuUsagePerMinute;
+		private int maxWorkersThroughputInMBPerMinute;
+		private int maxWorkersThroughputOutMBPerMinute;
 	}
 }


### PR DESCRIPTION
Added 6 parameters: 
`maxMemoryPerWorker`
`maxPublishedWorkers`
`maxWorkersMemorySizeMB`
`maxWorkersCpuUsagePerMinute`
`maxWorkersThroughputInMBPerMinute`
`maxWorkersThroughputOutMBPerMinute`