### PR TITLE
[CEP-195] Fix occasional HTTP 4xx stack-traces

### DIFF
--- a/src/main/java/com/c8db/internal/C8Errors.java
+++ b/src/main/java/com/c8db/internal/C8Errors.java
@@ -29,4 +29,6 @@ public final class C8Errors {
     public static final Integer ERROR_C8_DATABASE_NOT_FOUND = 1228;
     public static final Integer ERROR_GRAPH_NOT_FOUND = 1924;
     public static final Integer ERROR_STREAM_ALREADY_EXISTS = 100017;
+    public static final Integer ERROR_COLLECTION_ALREADY_EXISTS = 1207;
+
 }

--- a/src/main/java/com/c8db/internal/http/HttpConnection.java
+++ b/src/main/java/com/c8db/internal/http/HttpConnection.java
@@ -244,11 +244,11 @@ public class HttpConnection implements Connection {
             } else if (ex.getResponseCode() >= 500) {
                 LOGGER.error(String.format("C8DBException: Received HTTP %d. Retrying C8DB Connection", ex.getResponseCode()));
                 response = retryRequest(httpRequest);
-            } else if (ex.getResponseCode().equals(400) || ex.getResponseCode().equals(404)) {
+            } else if (ex.getResponseCode() >= 400) {
                 // Handle HTTP Error messages.
                 if (ex.getErrorNum() != null) {
                     // Here we only log the info and will not treat it as an exception.
-                    LOGGER.info("C8DBException: HTTP {} - [{}] {}.", ex.getResponseCode(),
+                    LOGGER.warn("C8DBException: HTTP {} - [{}] {}.", ex.getResponseCode(),
                             ex.getErrorNum(), ex.getErrorMessage());
                 }
                 checkError(response);


### PR DESCRIPTION
The purpose of this PR is to get rid of occasional HTTP 4xx stack traces occurring at c84j.  These will be propagated as `C8DBException`s and will get handled at c8cep.