### PR TITLE
STRM-204 Fix host resolution in multi-node setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,9 +315,9 @@
     </dependencyManagement>
 
     <scm>
-        <url>https://github.com-macrometa/Macrometacorp/C84j.git</url>
-        <connection>scm:git:git@github.com-macrometa:Macrometacorp/C84j.git</connection>
-        <developerConnection>scm:git:git@github.com-macrometa:Macrometacorp/C84j.git</developerConnection>
+        <url>https://github.com/Macrometacorp/C84j.git</url>
+        <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
+        <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
         <tag>c84j-1.1.11-SNAPSHOT</tag>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.11-SNAPSHOT</tag>
+        <tag>c84j-1.1.12-SNAPSHOT</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -315,9 +315,9 @@
     </dependencyManagement>
 
     <scm>
-        <url>https://github.com/Macrometacorp/C84j.git</url>
-        <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
-        <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
+        <url>https://github.com-macrometa/Macrometacorp/C84j.git</url>
+        <connection>scm:git:git@github.com-macrometa:Macrometacorp/C84j.git</connection>
+        <developerConnection>scm:git:git@github.com-macrometa:Macrometacorp/C84j.git</developerConnection>
         <tag>c84j-1.1.11-SNAPSHOT</tag>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.11</version>
+    <version>1.1.12-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -318,7 +318,7 @@
         <url>https://github.com-macrometa/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com-macrometa:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com-macrometa:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.11</tag>
+        <tag>c84j-1.1.11-SNAPSHOT</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.11-SNAPSHOT</version>
+    <version>1.1.11</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -318,7 +318,7 @@
         <url>https://github.com-macrometa/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com-macrometa:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com-macrometa:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.11-SNAPSHOT</tag>
+        <tag>c84j-1.1.11</tag>
     </scm>
 
     <organization>

--- a/src/main/java/com/c8db/internal/http/HttpCommunication.java
+++ b/src/main/java/com/c8db/internal/http/HttpCommunication.java
@@ -95,6 +95,7 @@ public class HttpCommunication implements Closeable {
                         LOGGER.warn(String.format("Could not connect to %s. Try connecting to %s",
                                 failedHost.getDescription(), host.getDescription()));
                     } else {
+                        hostHandler.reset();
                         throw se;
                     }
                 }


### PR DESCRIPTION
Master issue: [STRM-204](https://macrometa.atlassian.net/browse/STRM-204)

### Issue

In `multi-node`, when host resolution retries exhausted for one request, `c84j` does not resolve hosts for new requests. But it should retry for a new request. Otherwise, `db` object would be unusable after one failed request.

### Resolution

Now `c84j` will reset the retry count before sending the failure response to the first request. So new request will retry the host resolution.