### PR TITLE
Fix NullPointerException after 3 connection exceptions using FallbackHostHandler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.12-SNAPSHOT</version>
+    <version>1.1.12</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -318,7 +318,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.12-SNAPSHOT</tag>
+        <tag>c84j-1.1.12</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.12</version>
+    <version>1.1.13-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -318,7 +318,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.12</tag>
+        <tag>c84j-1.1.12-SNAPSHOT</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.12-SNAPSHOT</tag>
+        <tag>c84j-1.1.13-SNAPSHOT</tag>
     </scm>
 
     <organization>

--- a/src/main/java/com/c8db/entity/DcInfoEntity.java
+++ b/src/main/java/com/c8db/entity/DcInfoEntity.java
@@ -118,14 +118,15 @@ public class DcInfoEntity implements Entity {
     }
 
     public static class Tag {
-        private String role;
+
+        private String api;
         private String url;
 
         /**
          * @return the role
          */
-        public String getRole() {
-            return role;
+        public String getApi() {
+            return api;
         }
 
         /**

--- a/src/main/java/com/c8db/internal/http/HttpCommunication.java
+++ b/src/main/java/com/c8db/internal/http/HttpCommunication.java
@@ -95,7 +95,6 @@ public class HttpCommunication implements Closeable {
                         LOGGER.warn(String.format("Could not connect to %s. Try connecting to %s",
                                 failedHost.getDescription(), host.getDescription()));
                     } else {
-                        hostHandler.reset();
                         throw se;
                     }
                 }

--- a/src/main/java/com/c8db/internal/net/FallbackHostHandler.java
+++ b/src/main/java/com/c8db/internal/net/FallbackHostHandler.java
@@ -16,6 +16,8 @@
 
 package com.c8db.internal.net;
 
+import com.c8db.C8DBException;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -39,7 +41,12 @@ public class FallbackHostHandler implements HostHandler {
 
     @Override
     public Host get(final HostHandle hostHandle, AccessType accessType) {
-        return current != lastSuccess || iterations < 3 ? current : null;
+        if (current != lastSuccess || iterations < 3) {
+            return current;
+        } else {
+            reset();
+            throw new C8DBException("Cannot contact any host!");
+        }
     }
 
     @Override


### PR DESCRIPTION
The purpose of this PR is to fix the $title. This is the root cause for extensive NPEs in c8cep logs [1]. This issue is also reported and fixed in the ArangoDB [2] driver itself, and this is a port of that fix.

[1] https://macrometa.atlassian.net/browse/CEP-217
[2] https://github.com/arangodb/arangodb-java-driver/issues/246