### PR TITLE
Add methods streams permissions for user and apikey

### DIFF
--- a/src/main/java/com/c8db/C8ApiKeys.java
+++ b/src/main/java/com/c8db/C8ApiKeys.java
@@ -7,6 +7,8 @@ package com.c8db;
 import com.c8db.entity.ApiKeyEntity;
 import com.c8db.entity.Permissions;
 
+import java.util.Map;
+
 /**
  * Interface for operations on administration level.
  */
@@ -23,15 +25,23 @@ public interface C8ApiKeys extends C8SerializationAccessor {
     /**
      * Get the GeoFabric access level
      * @param keyId key id of a stream. ApiKey has the next structure: tenant.keyId.hash
-     * @return result of access level. Possible results are `ro`, `rw`, `none`
+     * @return result of access level.
      */
     Permissions getGeoFabricAccess(final String keyId);
+
+    /**
+     * Get access level for streams
+     * @param keyId key id of a stream. ApiKey has the next structure: tenant.keyId.hash
+     * @param full Return the full set of access levels for all streams. If set to false, return the read-only streams.
+     * @return result map of streams with access levels.
+     */
+    Map<String, Permissions> getStreamsAccess(final String keyId, final boolean full);
 
     /**
      * Get the stream access level
      * @param keyId key id of a stream. ApiKey has the next structure: tenant.keyId.hash
      * @param stream stream name
-     * @return result of access level. Possible results are `ro`, `rw`, `none`
+     * @return result of access level.
      */
     Permissions getStreamAccess(final String keyId, final String stream);
 

--- a/src/main/java/com/c8db/C8DB.java
+++ b/src/main/java/com/c8db/C8DB.java
@@ -983,17 +983,25 @@ public interface C8DB extends C8SerializationAccessor {
     void grantDefaultCollectionAccess(String user, Permissions permissions) throws C8DBException;
 
     /**
+     * Get access level for streams
+     * @param user user name
+     * @param full Return the full set of access levels for all streams. If set to false, return the read-only streams.
+     * @return result map of streams with access levels.
+     */
+    Map<String, Permissions> getStreamsAccess(final String user, final String tenant, final String fabric, final boolean full);
+
+    /**
      * Get the stream access level
      * @param user user name
      * @param stream stream name
-     * @return result of access level. Possible results are `ro`, `rw`, `none`
+     * @return result of access level.
      */
-    Permissions getStreamAccess(final String user, final String tenant, String fabric, final String stream);
+    Permissions getStreamAccess(final String user, final String tenant, final String fabric, final String stream);
 
     /**
      * Get the GeoFabric access level
      * @param user user name
-     * @return result of access level. Possible results are `ro`, `rw`, `none`
+     * @return result of access level.
      */
     Permissions getGeoFabricAccess(final String user, final String tenant, String fabric);
 

--- a/src/main/java/com/c8db/internal/C8ApiKeysImpl.java
+++ b/src/main/java/com/c8db/internal/C8ApiKeysImpl.java
@@ -8,6 +8,8 @@ import com.c8db.C8ApiKeys;
 import com.c8db.entity.ApiKeyEntity;
 import com.c8db.entity.Permissions;
 
+import java.util.Map;
+
 public class C8ApiKeysImpl extends InternalC8ApiKeys<C8DBImpl, C8DatabaseImpl, C8ExecutorSync>
         implements C8ApiKeys {
 
@@ -23,6 +25,11 @@ public class C8ApiKeysImpl extends InternalC8ApiKeys<C8DBImpl, C8DatabaseImpl, C
     @Override
     public Permissions getGeoFabricAccess(String keyId) {
         return executor.execute(geoFabricAccessLevelRequest(keyId), streamAccessLevelResponseDeserializer());
+    }
+
+    @Override
+    public Map<String, Permissions> getStreamsAccess(String keyId, boolean full) {
+        return executor.execute(streamsAccessLevelRequest(keyId, full), listAccessesResponseDeserializer());
     }
 
     @Override

--- a/src/main/java/com/c8db/internal/C8DBImpl.java
+++ b/src/main/java/com/c8db/internal/C8DBImpl.java
@@ -252,6 +252,12 @@ public class C8DBImpl extends InternalC8DB<C8ExecutorSync> implements C8DB {
     }
 
     @Override
+    public Map<String, Permissions> getStreamsAccess(final String user, final String tenant, final String fabric, final boolean full)
+        throws C8DBException {
+        return executor.execute(getUserStreamsAccessRequest(tenant, user, fabric, full), listAccessesResponseDeserializer());
+    }
+
+    @Override
     public Permissions getStreamAccess(final String user, final String tenant, final String fabric, final String stream)
         throws C8DBException {
         return executor.execute(getUserStreamAccessRequest(tenant, user, fabric, stream), accessResponseDeserializer());


### PR DESCRIPTION
Added the next methods `c8db.getStreamsAccess("d", "demo", "_system", true)` and `c8db.db("demo", "testgeo").apiKeys().getStreamsAccess("aaa", true)`
It needs for getting full streams access for all types of streams. A response includes also a result of `*`(other) streams. This result should be used for permissions for the creation of streams.