### PR TITLE
Synk Fix - Upgrade dependencies to resolve vulnerability issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.20-SNAPSHOT</version>
+    <version>1.1.20</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -34,7 +34,7 @@
         <junit.version>4.13.1</junit.version>
 
         <!-- javadoc -->
-        <javadoc.opts/>
+        <javadoc.opts />
     </properties>
 
     <developers>
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.18-SNAPSHOT</tag>
+        <tag>c84j-1.1.20</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.20</version>
+    <version>1.1.21-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.20</tag>
+        <tag>c84j-1.1.18-SNAPSHOT</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <slf4j-api.version>1.7.32</slf4j-api.version>
+        <slf4j-api.version>1.7.36</slf4j-api.version>
         <arangodb.velocypack.version>1.4.3</arangodb.velocypack.version>
-        <jackson.version>2.13.1</jackson.version>
+        <jackson.databind.version>2.13.2.2</jackson.databind.version>
+        <jackson.version>2.13.2</jackson.version>
         <!-- provided -->
         <httpclient.version>4.5.13</httpclient.version>
 
@@ -33,7 +34,7 @@
         <junit.version>4.13.1</junit.version>
 
         <!-- javadoc -->
-        <javadoc.opts />
+        <javadoc.opts/>
     </properties>
 
     <developers>
@@ -254,7 +255,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -275,7 +276,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-dynamodb</artifactId>
-            <version>1.11.774</version>
+            <version>1.12.202</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>


### PR DESCRIPTION
This PR upgrades the below mentioned dependencies , due to vulnerability issue -
1. org.slf4j:slf4j-api from 1.7.32 to 1.7.36 (https://github.com/Macrometacorp/c84j/pull/50, https://github.com/Macrometacorp/c84j/pull/52)
2. com.fasterxml.jackson.core:jackson-databind from 2.13.1 to 2.13.2.1 (https://github.com/Macrometacorp/c84j/pull/56)
3. com.amazonaws:aws-java-sdk-dynamodb: 1.11.774 -> 1.12.189
   com.fasterxml.jackson.core:jackson-databind: 2.13.1 -> 2.13.2.1  (https://github.com/Macrometacorp/c84j/pull/53, https://github.com/Macrometacorp/c84j/pull/51)