### PR TITLE
STRM-327: Fix path and methods for user

### DIFF
--- a/src/main/java/com/c8db/C8DB.java
+++ b/src/main/java/com/c8db/C8DB.java
@@ -749,6 +749,19 @@ public interface C8DB extends C8SerializationAccessor {
     Collection<String> getAccessibleGeoFabricsFor(String user) throws C8DBException;
 
     /**
+     * List available database to the specified user
+     *
+     * @see <a href=
+     *      "https://docs.arangodb.com/current/HTTP/UserManagement/index.html#list-the-databases-available-to-a-user">API
+     *      Documentation</a>
+     * @param tenant Name of the tenant
+     * @param user The name of the user for which you want to query the databases
+     * @return list of database names which are available for the specified user
+     * @throws C8DBException
+     */
+    Collection<String> getAccessibleGeoFabricsFor(String tenant, String user) throws C8DBException;
+
+    /**
      * Updated the data centers for the specified database
      * 
      * @param tenant Name of the tenant
@@ -857,10 +870,11 @@ public interface C8DB extends C8SerializationAccessor {
      *      Documentation</a>
      * @param user   The name of the user
      * @param passwd The user password
+     * @param email  The user email
      * @return information about the user
      * @throws C8DBException
      */
-    UserEntity createUser(String user, String passwd) throws C8DBException;
+    UserEntity createUser(String user, String passwd, String email) throws C8DBException;
 
     /**
      * Create a new user. This user will not have access to any database. You need
@@ -871,11 +885,12 @@ public interface C8DB extends C8SerializationAccessor {
      *      Documentation</a>
      * @param user    The name of the user
      * @param passwd  The user password
+     * @param email  The user email
      * @param options Additional options, can be null
      * @return information about the user
      * @throws C8DBException
      */
-    UserEntity createUser(String user, String passwd, UserCreateOptions options) throws C8DBException;
+    UserEntity createUser(String user, String passwd, String email, UserCreateOptions options) throws C8DBException;
 
     /**
      * Removes an existing user, identified by user. You need access to the _system
@@ -964,27 +979,31 @@ public interface C8DB extends C8SerializationAccessor {
      * Sets the default access level for databases for the user {@code user}. You
      * need permission to the _system database in order to execute this call.
      *
+     * @param tenant      The tenant of the user
      * @param user        The name of the user
      * @param permissions The permissions the user grant
      * @since ArangoDB 3.2.0
      * @throws C8DBException
      */
-    void grantDefaultDatabaseAccess(String user, Permissions permissions) throws C8DBException;
+    void grantDefaultDatabaseAccess(final String tenant, String user, Permissions permissions) throws C8DBException;
 
     /**
      * Sets the default access level for collections for the user {@code user}. You
      * need permission to the _system database in order to execute this call.
      *
+     * @param tenant      The tenant of the user
      * @param user        The name of the user
      * @param permissions The permissions the user grant
      * @since ArangoDB 3.2.0
      * @throws C8DBException
      */
-    void grantDefaultCollectionAccess(String user, Permissions permissions) throws C8DBException;
+    void grantDefaultCollectionAccess(final String tenant, String user, Permissions permissions) throws C8DBException;
 
     /**
      * Get access level for streams
-     * @param user user name
+     *
+     * @param user        The name of the user
+     * @param tenant      The tenant of the user
      * @param full Return the full set of access levels for all streams. If set to false, return the read-only streams.
      * @return result map of streams with access levels.
      */
@@ -992,15 +1011,20 @@ public interface C8DB extends C8SerializationAccessor {
 
     /**
      * Get the stream access level
-     * @param user user name
-     * @param stream stream name
+     *
+     * @param user        The name of the user
+     * @param stream      The stream name
+     * @param tenant      The tenant of the user
      * @return result of access level.
      */
     Permissions getStreamAccess(final String user, final String tenant, final String fabric, final String stream);
 
     /**
      * Get the GeoFabric access level
-     * @param user user name
+     *
+     * @param user        The name of the user
+     * @param tenant      The tenant of the user
+     * @param fabric      The fabric of the user
      * @return result of access level.
      */
     Permissions getGeoFabricAccess(final String user, final String tenant, String fabric);

--- a/src/main/java/com/c8db/internal/C8DBImpl.java
+++ b/src/main/java/com/c8db/internal/C8DBImpl.java
@@ -146,6 +146,12 @@ public class C8DBImpl extends InternalC8DB<C8ExecutorSync> implements C8DB {
     }
 
     @Override
+    public Collection<String> getAccessibleGeoFabricsFor(final String tenant, final String user) throws C8DBException {
+        return executor.execute(getAccessibleGeoFabricsForRequest(tenant, db().name(), user),
+            getAccessibleGeoFabricsForResponseDeserializer());
+    }
+
+    @Override
     public Boolean updateDataCentersForGeoFabric(final String tenant, final String name, final String dcList) throws C8DBException {
         return executor.execute(updateDCListRequest(tenant, name, dcList), updateDCListResponseDeserializer());
     }
@@ -199,15 +205,15 @@ public class C8DBImpl extends InternalC8DB<C8ExecutorSync> implements C8DB {
 
     //TODO: probably delete this
     @Override
-    public UserEntity createUser(final String user, final String passwd) throws C8DBException {
-        return executor.execute(createUserRequest(db().tenant(), C8RequestParam.SYSTEM, user, passwd, new UserCreateOptions()),
+    public UserEntity createUser(final String user, final String passwd, final String email) throws C8DBException {
+        return executor.execute(createUserRequest(db().tenant(), C8RequestParam.SYSTEM, user, passwd, email, new UserCreateOptions()),
                 UserEntity.class);
     }
 
     @Override
-    public UserEntity createUser(final String user, final String passwd, final UserCreateOptions options)
+    public UserEntity createUser(final String user, final String passwd, final String email, final UserCreateOptions options)
             throws C8DBException {
-        return executor.execute(createUserRequest(db().tenant(), C8RequestParam.SYSTEM, user, passwd, options), UserEntity.class);
+        return executor.execute(createUserRequest(db().tenant(), C8RequestParam.SYSTEM, user, passwd, email, options), UserEntity.class);
     }
 
     @Override
@@ -241,14 +247,14 @@ public class C8DBImpl extends InternalC8DB<C8ExecutorSync> implements C8DB {
     }
 
     @Override
-    public void grantDefaultDatabaseAccess(final String user, final Permissions permissions) throws C8DBException {
-        executor.execute(updateUserDefaultDatabaseAccessRequest(user, permissions), Void.class);
+    public void grantDefaultDatabaseAccess(final String tenant, final String user, final Permissions permissions) throws C8DBException {
+        executor.execute(updateUserDefaultDatabaseAccessRequest(tenant, user, permissions), Void.class);
     }
 
     @Override
-    public void grantDefaultCollectionAccess(final String user, final Permissions permissions)
+    public void grantDefaultCollectionAccess(final String tenant, final String user, final Permissions permissions)
             throws C8DBException {
-        executor.execute(updateUserDefaultCollectionAccessRequest(user, permissions), Void.class);
+        executor.execute(updateUserDefaultCollectionAccessRequest(tenant, user, permissions), Void.class);
     }
 
     @Override

--- a/src/main/java/com/c8db/model/OptionsBuilder.java
+++ b/src/main/java/com/c8db/model/OptionsBuilder.java
@@ -22,8 +22,8 @@ public class OptionsBuilder {
         super();
     }
 
-    public static UserCreateOptions build(final UserCreateOptions options, final String user, final String passwd) {
-        return options.user(user).passwd(passwd);
+    public static UserCreateOptions build(final UserCreateOptions options, final String user, final String passwd, final String email) {
+        return options.user(user).passwd(passwd).email(email);
     }
 
     public static HashIndexOptions build(final HashIndexOptions options, final Iterable<String> fields) {

--- a/src/main/java/com/c8db/model/UserCreateOptions.java
+++ b/src/main/java/com/c8db/model/UserCreateOptions.java
@@ -26,6 +26,8 @@ public class UserCreateOptions {
     private String user;
     private String passwd;
     private Boolean active;
+    private String email;
+
     private Map<String, Object> extra;
 
     public UserCreateOptions() {
@@ -69,6 +71,19 @@ public class UserCreateOptions {
      */
     public UserCreateOptions active(final Boolean active) {
         this.active = active;
+        return this;
+    }
+
+    protected String getEmail() {
+        return email;
+    }
+
+    /**
+     * @param email The user email
+     * @return options
+     */
+    protected UserCreateOptions email(final String email) {
+        this.email = email;
         return this;
     }
 

--- a/src/test/java/com/c8db/C8DBTest.java
+++ b/src/test/java/com/c8db/C8DBTest.java
@@ -60,6 +60,7 @@ public class C8DBTest {
     private static final String ROOT = "root";
     private static final String USER = "test_user";
     private static final String PW = "machts der hund";
+    private static final String EMAIL = "aaa@bb.cc";
     private final C8DB c8DB;
 
     public C8DBTest(final Builder builder) {
@@ -259,7 +260,7 @@ public class C8DBTest {
         try {
             final Map<String, Object> extra = new HashMap<String, Object>();
             extra.put("hund", false);
-            c8DB.createUser(USER, PW, new UserCreateOptions().extra(extra));
+            c8DB.createUser(USER, PW, EMAIL, new UserCreateOptions().extra(extra));
             extra.put("hund", true);
             extra.put("mund", true);
             final UserEntity user = c8DB.updateUser(USER, new UserUpdateOptions().extra(extra));
@@ -282,7 +283,7 @@ public class C8DBTest {
         try {
             final Map<String, Object> extra = new HashMap<String, Object>();
             extra.put("hund", false);
-            c8DB.createUser(USER, PW, new UserCreateOptions().extra(extra));
+            c8DB.createUser(USER, PW, EMAIL, new UserCreateOptions().extra(extra));
             extra.remove("hund");
             extra.put("mund", true);
             final UserEntity user = c8DB.replaceUser(USER, new UserUpdateOptions().extra(extra));
@@ -302,8 +303,8 @@ public class C8DBTest {
     @Test
     public void updateUserDefaultDatabaseAccess() {
         try {
-            c8DB.createUser(USER, PW);
-            c8DB.grantDefaultDatabaseAccess(USER, Permissions.RW);
+            c8DB.createUser(USER, PW, EMAIL);
+            c8DB.grantDefaultDatabaseAccess(C8RequestParam.DEMO_TENANT, USER, Permissions.RW);
         } finally {
             c8DB.deleteUser(USER);
         }
@@ -312,8 +313,8 @@ public class C8DBTest {
     @Test
     public void updateUserDefaultCollectionAccess() {
         try {
-            c8DB.createUser(USER, PW);
-            c8DB.grantDefaultCollectionAccess(USER, Permissions.RW);
+            c8DB.createUser(USER, PW, EMAIL);
+            c8DB.grantDefaultCollectionAccess(C8RequestParam.DEMO_TENANT, USER, Permissions.RW);
         } finally {
             c8DB.deleteUser(USER);
         }

--- a/src/test/java/com/c8db/UserAuthTest.java
+++ b/src/test/java/com/c8db/UserAuthTest.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 
+import com.c8db.internal.C8RequestParam;
 import org.junit.AfterClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -46,6 +47,7 @@ public class UserAuthTest {
     private static final String COLLECTION_NAME = "AuthUnitTestCollection";
     private static final String COLLECTION_NAME_NEW = COLLECTION_NAME + "new";
     private static final String USER_NAME = "AuthUnitTestUser";
+    private static final String EMAIL = "aa@cc.bb";
     private static final String USER_NAME_NEW = USER_NAME + "new";
 
     public static class UserAuthParam {
@@ -93,7 +95,7 @@ public class UserAuthTest {
             shutdown();
         }
         c8DBRoot = new C8DB.Builder().useProtocol(param.protocol).build();
-        c8DBRoot.createUser(USER_NAME, "");
+        c8DBRoot.createUser(USER_NAME, "", EMAIL);
         c8DB = new C8DB.Builder().useProtocol(param.protocol).user(USER_NAME).build();
         c8DBRoot.createGeoFabric(C8Defaults.DEFAULT_TENANT, DB_NAME, "", C8Defaults.DEFAULT_DC_LIST, DB_NAME);
         c8DBRoot.db(C8Defaults.DEFAULT_TENANT, DB_NAME).createCollection(COLLECTION_NAME);
@@ -179,14 +181,14 @@ public class UserAuthTest {
         try {
             if (Permissions.RW.equals(param.systemPermission)) {
                 try {
-                    c8DB.createUser(USER_NAME_NEW, "");
+                    c8DB.createUser(USER_NAME_NEW, "", EMAIL);
                 } catch (final C8DBException e) {
                     fail(details);
                 }
                 assertThat(details, c8DBRoot.getUsers(), is(notNullValue()));
             } else {
                 try {
-                    c8DB.createUser(USER_NAME_NEW, "");
+                    c8DB.createUser(USER_NAME_NEW, "", EMAIL);
                     fail(details);
                 } catch (final C8DBException e) {
                 }
@@ -207,7 +209,7 @@ public class UserAuthTest {
     @Test
     public void deleteUser() {
         try {
-            c8DBRoot.createUser(USER_NAME_NEW, "");
+            c8DBRoot.createUser(USER_NAME_NEW, "", EMAIL);
             if (Permissions.RW.equals(param.systemPermission)) {
                 try {
                     c8DB.deleteUser(USER_NAME_NEW);
@@ -238,7 +240,7 @@ public class UserAuthTest {
     @Test
     public void updateUser() {
         try {
-            c8DBRoot.createUser(USER_NAME_NEW, "");
+            c8DBRoot.createUser(USER_NAME_NEW, "", EMAIL);
             if (Permissions.RW.equals(param.systemPermission)) {
                 try {
                     c8DB.updateUser(USER_NAME_NEW, new UserUpdateOptions().active(false));
@@ -265,7 +267,7 @@ public class UserAuthTest {
     @Test
     public void grantUserDBAccess() {
         try {
-            c8DBRoot.createUser(USER_NAME_NEW, "");
+            c8DBRoot.createUser(USER_NAME_NEW, "", EMAIL);
             if (Permissions.RW.equals(param.systemPermission)) {
                 try {
                     c8DB.db().grantAccess(USER_NAME_NEW);
@@ -290,7 +292,7 @@ public class UserAuthTest {
     @Test
     public void resetUserDBAccess() {
         try {
-            c8DBRoot.createUser(USER_NAME_NEW, "");
+            c8DBRoot.createUser(USER_NAME_NEW, "", EMAIL);
             c8DBRoot.db().grantAccess(USER_NAME_NEW);
             if (Permissions.RW.equals(param.systemPermission)) {
                 try {
@@ -316,7 +318,7 @@ public class UserAuthTest {
     @Test
     public void grantUserCollcetionAccess() {
         try {
-            c8DBRoot.createUser(USER_NAME_NEW, "");
+            c8DBRoot.createUser(USER_NAME_NEW, "", EMAIL);
             if (Permissions.RW.equals(param.systemPermission)) {
                 try {
                     c8DB.db(C8Defaults.DEFAULT_TENANT, DB_NAME).collection(COLLECTION_NAME)
@@ -343,7 +345,7 @@ public class UserAuthTest {
     @Test
     public void resetUserCollectionAccess() {
         try {
-            c8DBRoot.createUser(USER_NAME_NEW, "");
+            c8DBRoot.createUser(USER_NAME_NEW, "", EMAIL);
             c8DBRoot.db().grantAccess(USER_NAME_NEW);
             if (Permissions.RW.equals(param.systemPermission)) {
                 try {
@@ -371,17 +373,17 @@ public class UserAuthTest {
     @Test
     public void updateUserDefaultDatabaseAccess() {
         try {
-            c8DBRoot.createUser(USER_NAME_NEW, "");
+            c8DBRoot.createUser(USER_NAME_NEW, "", EMAIL);
             c8DBRoot.db().grantAccess(USER_NAME_NEW);
             if (Permissions.RW.equals(param.systemPermission)) {
                 try {
-                    c8DB.grantDefaultDatabaseAccess(USER_NAME_NEW, Permissions.RW);
+                    c8DB.grantDefaultDatabaseAccess(C8RequestParam.DEMO_TENANT, USER_NAME_NEW, Permissions.RW);
                 } catch (final C8DBException e) {
                     fail(details);
                 }
             } else {
                 try {
-                    c8DB.grantDefaultDatabaseAccess(USER_NAME_NEW, Permissions.RW);
+                    c8DB.grantDefaultDatabaseAccess(C8RequestParam.DEMO_TENANT, USER_NAME_NEW, Permissions.RW);
                     fail(details);
                 } catch (final C8DBException e) {
                 }
@@ -397,17 +399,17 @@ public class UserAuthTest {
     @Test
     public void updateUserDefaultCollectionAccess() {
         try {
-            c8DBRoot.createUser(USER_NAME_NEW, "");
+            c8DBRoot.createUser(USER_NAME_NEW, "", EMAIL);
             c8DBRoot.db().grantAccess(USER_NAME_NEW);
             if (Permissions.RW.equals(param.systemPermission)) {
                 try {
-                    c8DB.grantDefaultCollectionAccess(USER_NAME_NEW, Permissions.RW);
+                    c8DB.grantDefaultCollectionAccess(C8RequestParam.DEMO_TENANT, USER_NAME_NEW, Permissions.RW);
                 } catch (final C8DBException e) {
                     fail(details);
                 }
             } else {
                 try {
-                    c8DB.grantDefaultCollectionAccess(USER_NAME_NEW, Permissions.RW);
+                    c8DB.grantDefaultCollectionAccess(C8RequestParam.DEMO_TENANT, USER_NAME_NEW, Permissions.RW);
                     fail(details);
                 } catch (final C8DBException e) {
                 }


### PR DESCRIPTION
The main reason if this PR is to fix `getStreamsAccess` method
now it calls to
```
`curl -X 'GET' \
  'https://api-smoke1.eng.macrometa.io:443/_tenant/demo/_fabric/_system/_admin/user/root/database/_system/stream?full=true' \
  -H 'accept: application/json' \
  -H 'Authorization: bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjEuNjUxNzM4NzQ0MTI4MTE0ZSs2LCJoYXNoIjo1OTczNjY5MDA3Njk5NzU3NjY5LCJleHAiOjE5NjcwOTg3NDQsImlzcyI6Im1hY3JvbWV0YSIsInByZWZlcnJlZF91c2VybmFtZSI6InNlcnZpY2UiLCJzdWIiOiJhZG1pbiIsInRlbmFudCI6Il9tbSJ9.n45vbXpEOG5Y4RvrRRlGTdxPqByGEFhK8LOmpaxl_pg='
```
with path that includes `_admin`
it worked well previously and this path set in our `c84j`.
But if change path to our official endpoint(with `_api` in path)  then it will works again
```
curl -X 'GET' \
  'https://api-smoke1.eng.macrometa.io:443/_tenant/demo/_fabric/_system/_api/user/root/database/_system/stream?full=true' \
  -H 'accept: application/json' \
  -H 'Authorization: bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjEuNjUxNzM4NzQ0MTI4MTE0ZSs2LCJoYXNoIjo1OTczNjY5MDA3Njk5NzU3NjY5LCJleHAiOjE5NjcwOTg3NDQsImlzcyI6Im1hY3JvbWV0YSIsInByZWZlcnJlZF91c2VybmFtZSI6InNlcnZpY2UiLCJzdWIiOiJhZG1pbiIsInRlbmFudCI6Il9tbSJ9.n45vbXpEOG5Y4RvrRRlGTdxPqByGEFhK8LOmpaxl_pg='
```
It seems that path with _admin  is redundant and we must keep a new one.

Change `PATH_API_USER = "/_adim/user";` -> `PATH_API_USER = "/_api/user";` uses in other methods that uses for User API, they didn't work properly. I fixed them also. 

The important thing in usage methods is to use a username with tenant like here:
```
        UserEntity user2 = c8db.getUser("demo.test3");
        Collection<String> geoses = c8db.getAccessibleGeoFabricsFor("demo.test3");
        UserEntity updatedUser = c8db.updateUser("demo.test3", new UserUpdateOptions().active(false));
        UserEntity replacedUser = c8db.replaceUser("demo.test3", new UserUpdateOptions().active(true));
```
        
