### PR TITLE
Fix all streams methods

### DIFF
--- a/src/main/java/com/c8db/C8Database.java
+++ b/src/main/java/com/c8db/C8Database.java
@@ -564,7 +564,7 @@ public interface C8Database extends C8SerializationAccessor {
     /**
      * Returns a {@code C8Stream} instance for the given stream name.
      *
-     * @param name Name of the stream
+     * @param name Name of the stream with either `c8locals.`, `c8globals.` or without prefix for collections' streams.
      * @return stream handler
      */
     C8Stream stream(String name);
@@ -572,11 +572,12 @@ public interface C8Database extends C8SerializationAccessor {
     /**
      * Create asynchronously a persistent stream for a given fabric.
      *
-     * @param name    of the stream
+     * @param name    of the stream without `c8locals.` or `c8globals.` prefix.
      * @param options C8StreamCreateOptions
      * @throws C8DBException
+     * @return return full name of stream.
      */
-    void createPersistentStream(final String name, final C8StreamCreateOptions options) throws C8DBException;
+    String createPersistentStream(final String name, final C8StreamCreateOptions options) throws C8DBException;
 
     /**
      * Get list of persistent streams under the given stream db. Returns either a
@@ -598,22 +599,38 @@ public interface C8Database extends C8SerializationAccessor {
 
     /**
      * Clear backlog for all streams on a stream db.
+     * @param isLocal Operate on a local namespace instead of a global one. Default value: false
      */
-    void clearBacklog();
+    void clearBacklog(final boolean isLocal);
+
+    /**
+     * Get TTL for all streams on a stream db.
+     * @param isLocal Operate on a local namespace instead of a global one. Default value: false
+     */
+    int getTtlMessages(final boolean isLocal);
+
+    /**
+     * Set TTL for all streams on a stream db.
+     * @param ttl set time to live for messages
+     * @param isLocal Operate on a local namespace instead of a global one. Default value: false
+     */
+    void ttlMessages(final int ttl, final boolean isLocal);
 
     /**
      * Clear backlog for given subscription.
      *
      * @param subscriptionName Name of the subscription
+     * @param isLocal Operate on a local namespace instead of a global one. Default value: false
      */
-    void clearBacklog(final String subscriptionName);
+    void clearBacklog(final String subscriptionName, final boolean isLocal);
 
     /**
      * Unsubscribes the given subscription on all streams on a stream db.
      *
      * @param subscriptionName Identifying name of the subscripton.
+     * @param isLocal Operate on a local namespace instead of a global one. Default value: false
      */
-    void unsubscribe(final String subscriptionName);
+    void unsubscribe(final String subscriptionName, final boolean isLocal);
 
     /**
      * Creates user query as the current user

--- a/src/main/java/com/c8db/C8Stream.java
+++ b/src/main/java/com/c8db/C8Stream.java
@@ -49,71 +49,34 @@ public interface C8Stream extends C8SerializationAccessor {
      * 
      * @return
      */
-    C8StreamBacklogEntity getBacklog(final boolean isLocal);
+    C8StreamBacklogEntity getBacklog();
     
     /**
      * Get the statistics for the given stream.
-     * @param isLocal Operate on a local stream instead of a global one. Default value: false
      * @return
      */
-    C8StreamStatisticsEntity getStatistics(final boolean isLocal);
+    C8StreamStatisticsEntity getStatistics();
     
     /**
-     * Terminate a stream. A stream that is terminated will not accept any more messages to be published and will let consumer to drain existing messages in backlog.
-     * @param isLocal Operate on a local stream instead of a global one. Default value: false
-     * @return
+     * Delete a stream. A stream that is deleted will not accept any more messages to be published and will let consumers drain existing messages in a backlog.
      */
-    void terminate(final boolean isLocal);
+    void delete();
     
     /**
      * Get the list of persistent subscriptions for a given stream.
-     * @param isLocal Operate on a local stream instead of a global one. Default value: false
      * @return
      */
-    Collection<String> getSubscriptions(final boolean isLocal);
-
-    /**
-     * Skip num messages on a topic subscription.
-     * @param subscriptionName Identification name of the subscription.
-     * @param numberOfMessages Number of messages to skip.
-     * @param isLocal Operate on a local stream instead of a global one. 
-     */
-    void skipMessages(final String subscriptionName, int numberOfMessages, boolean isLocal);
-
-    /**
-     * Skip all messages on a stream subscription.
-     * @param subscriptionName Identification name of the subscription.
-     * @param isLocal Operate on a local stream instead of a global one.
-     */
-    void skipAllMessages(final String subscriptionName, boolean isLocal);
-
-    /**
-     * Reset subscription to message position closest to absolute timestamp (in miliseconds).
-     * @param subscriptionName Identification name of the subscription.
-     * @param timestamp Timestamp in miliseconds.
-     * @param isLocal Operate on a local stream instead of a global one.
-     */
-    void resetCursorToTimestamp(final String subscriptionName, int timestamp, boolean isLocal);
-
-    /**
-     * Disconnect all active consumers for a cursor and reset the cursor.
-     * @param subscriptionName Identification name of the subscription.
-     * @param isLocal Operate on a local stream instead of a global one.
-     */
-    void resetCursor(String subscriptionName, boolean isLocal);
+    Collection<String> getSubscriptions();
 
     /**
      * Expire messages on a stream subscription.
-     * @param subscriptionName Identification name of the subscription.
      * @param expireTimeInSeconds Expiration time in seconds.
-     * @param isLocal Operate on a local stream instead of a global one.
      */
-    void expireMessagesInSeconds(String subscriptionName, int expireTimeInSeconds, boolean isLocal);
+    void expireMessagesInSeconds(int expireTimeInSeconds);
 
     /**
      * Delete a subscription.
      * @param subscriptionName Identification name of the subscription.
-     * @param isLocal Operate on a local stream instead of a global one.
      */
-    void deleteSubscription(String subscriptionName, boolean isLocal);
+    void deleteSubscription(String subscriptionName);
 }

--- a/src/main/java/com/c8db/internal/C8StreamImpl.java
+++ b/src/main/java/com/c8db/internal/C8StreamImpl.java
@@ -19,6 +19,7 @@ package com.c8db.internal;
 import java.util.Collection;
 
 import com.c8db.C8Stream;
+import com.c8db.Service;
 import com.c8db.entity.C8StreamBacklogEntity;
 import com.c8db.entity.C8StreamStatisticsEntity;
 
@@ -33,54 +34,33 @@ public class C8StreamImpl extends InternalC8Stream<C8DBImpl, C8DatabaseImpl, C8E
     }
 
     @Override
-    public C8StreamBacklogEntity getBacklog(final boolean isLocal) {
-        return executor.execute(getC8StreamBacklogRequest(isLocal), getC8StreamBacklogResponseDeserializer());
+    public C8StreamBacklogEntity getBacklog() {
+        return executor.execute(getC8StreamBacklogRequest(), getC8StreamBacklogResponseDeserializer(), null, Service.C8STREAMS);
     }
 
     @Override
-    public C8StreamStatisticsEntity getStatistics(final boolean isLocal) {
-        return executor.execute(getC8StreamStatisticsRequest(isLocal), getC8StreamStatisticsResponseDeserializer());
+    public C8StreamStatisticsEntity getStatistics() {
+        return executor.execute(getC8StreamStatisticsRequest(), getC8StreamStatisticsResponseDeserializer(), null, Service.C8STREAMS);
     }
 
     @Override
-    public void terminate(final boolean isLocal) {
-        executor.execute(terminateC8StreamRequest(isLocal), Void.class);
+    public void delete() {
+        executor.execute(deleteC8StreamRequest(), Void.class, null, Service.C8STREAMS);
     }
 
     @Override
-    public Collection<String> getSubscriptions(final boolean isLocal) {
-        return executor.execute(getC8StreamSubscriptionsRequest(isLocal),
-                getC8StreamSubscriptionsResponseDeserializer());
+    public Collection<String> getSubscriptions() {
+        return executor.execute(getC8StreamSubscriptionsRequest(),
+                getC8StreamSubscriptionsResponseDeserializer(), null, Service.C8STREAMS);
     }
 
     @Override
-    public void skipMessages(final String subscriptionName, final int numberOfMessages, final boolean isLocal) {
-        executor.execute(skipMessagesRequest(subscriptionName, numberOfMessages, isLocal), Void.class);
-    }
-
-    @Override
-    public void skipAllMessages(final String subscriptionName, final boolean isLocal) {
-        executor.execute(skipAllMessagesRequest(subscriptionName, isLocal), Void.class);
-    }
-
-    @Override
-    public void resetCursorToTimestamp(final String subscriptionName, final int timestamp, final boolean isLocal) {
-        executor.execute(resetCursorRequest(subscriptionName, timestamp, isLocal), Void.class);
-    }
-
-    @Override
-    public void resetCursor(final String subscriptionName, final boolean isLocal) {
-        executor.execute(resetCursorRequest(subscriptionName, isLocal), Void.class);
-    }
-
-    @Override
-    public void expireMessagesInSeconds(final String subscriptionName, final int expireTimeInSeconds,
-            final boolean isLocal) {
-        executor.execute(expireMessagesRequest(subscriptionName, expireTimeInSeconds, isLocal), Void.class);
+    public void expireMessagesInSeconds(final int expireTimeInSeconds) {
+        executor.execute(expireMessagesRequest(expireTimeInSeconds), Void.class, null, Service.C8STREAMS);
     }
     
     @Override
-    public void deleteSubscription(final String subscriptionName, final boolean isLocal) {
-        executor.execute(deleteSubscriptionRequest(subscriptionName, isLocal), Void.class);
+    public void deleteSubscription(final String subscriptionName) {
+        executor.execute(deleteSubscriptionRequest(subscriptionName), Void.class, null, Service.C8STREAMS);
     }
 }

--- a/src/main/java/com/c8db/internal/InternalC8Stream.java
+++ b/src/main/java/com/c8db/internal/InternalC8Stream.java
@@ -19,6 +19,7 @@ package com.c8db.internal;
 import java.io.IOException;
 import java.util.Collection;
 
+import com.arangodb.velocypack.Type;
 import com.arangodb.velocypack.VPackSlice;
 import com.arangodb.velocypack.exception.VPackException;
 import com.c8db.C8DBException;
@@ -37,7 +38,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public abstract class InternalC8Stream<A extends InternalC8DB<E>, D extends InternalC8Database<A, E>, E extends C8Executor>
         extends C8Executeable<E> {
 
-    protected static final String PATH_API_STREAMS = "/streams/persistent/stream";
+    protected static final String PATH_API_STREAMS = "/_api/streams";
 
     private final D db;
     private final String name;
@@ -56,23 +57,8 @@ public abstract class InternalC8Stream<A extends InternalC8DB<E>, D extends Inte
         return name;
     }
 
-    protected Request dropRequest() {
-        return dropRequest(false);
-    }
-
-    protected Request dropRequest(final boolean isLocal) {
-        final Request request = request(db.tenant(), db.name(), RequestType.DELETE, PATH_API_STREAMS, name);
-        if (isLocal) {
-            request.putQueryParam("local", isLocal);
-        }
-        return request;
-    }
-
-    protected Request getC8StreamBacklogRequest(final boolean isLocal) {
+    protected Request getC8StreamBacklogRequest() {
         final Request request = request(db.tenant(), db.name(), RequestType.GET, PATH_API_STREAMS, name, "backlog");
-        if (isLocal) {
-            request.putQueryParam("local", isLocal);
-        }
         return request;
     }
 
@@ -80,21 +66,15 @@ public abstract class InternalC8Stream<A extends InternalC8DB<E>, D extends Inte
         return new ResponseDeserializer<C8StreamBacklogEntity>() {
             @Override
             public C8StreamBacklogEntity deserialize(final Response response) throws VPackException {
-                final VPackSlice body = response.getBody().get(C8ResponseField.RESULT);
-                try {
-                    return new ObjectMapper().readValue(body.getAsString(), C8StreamBacklogEntity.class);
-                } catch (IOException e) {
-                    throw new C8DBException(e.getMessage());
-                }
+                final VPackSlice result = response.getBody().get(C8ResponseField.RESULT);
+                return util().deserialize(result, new Type<C8StreamBacklogEntity>() {
+                }.getType());
             }
         };
     }
 
-    protected Request getC8StreamStatisticsRequest(final boolean isLocal) {
+    protected Request getC8StreamStatisticsRequest() {
         final Request request = request(db.tenant(), db.name(), RequestType.GET, PATH_API_STREAMS, name, "stats");
-        if (isLocal) {
-            request.putQueryParam("local", isLocal);
-        }
         return request;
     }
 
@@ -102,39 +82,21 @@ public abstract class InternalC8Stream<A extends InternalC8DB<E>, D extends Inte
         return new ResponseDeserializer<C8StreamStatisticsEntity>() {
             @Override
             public C8StreamStatisticsEntity deserialize(final Response response) throws VPackException {
-                final VPackSlice body = response.getBody().get(C8ResponseField.RESULT);
-                try {
-                    return new ObjectMapper().readValue(body.getAsString(), C8StreamStatisticsEntity.class);
-                } catch (IOException e) {
-                    throw new C8DBException(e.getMessage());
-                }
+                final VPackSlice result = response.getBody().get(C8ResponseField.RESULT);
+                return util().deserialize(result, new Type<C8StreamStatisticsEntity>() {
+                }.getType());
             }
         };
     }
 
-    protected Request terminateC8StreamRequest(final boolean isLocal) {
-        final Request request = request(db.tenant(), db.name(), RequestType.POST, PATH_API_STREAMS, name, "terminate");
-        if (isLocal) {
-            request.putQueryParam("local", isLocal);
-        }
+    protected Request deleteC8StreamRequest() {
+        final Request request = request(db.tenant(), db.name(), RequestType.DELETE, PATH_API_STREAMS, name);
         return request;
     }
 
-    protected ResponseDeserializer<Boolean> booleanResponseDeserializer() {
-        return new ResponseDeserializer<Boolean>() {
-            @Override
-            public Boolean deserialize(final Response response) throws VPackException {
-                return response.getBody().getAsBoolean();
-            }
-        };
-    }
-
-    protected Request getC8StreamSubscriptionsRequest(boolean isLocal) {
+    protected Request getC8StreamSubscriptionsRequest() {
         final Request request = request(db.tenant(), db.name(), RequestType.GET, PATH_API_STREAMS, name,
                 "subscriptions");
-        if (isLocal) {
-            request.putQueryParam("local", isLocal);
-        }
         return request;
     }
 
@@ -143,68 +105,21 @@ public abstract class InternalC8Stream<A extends InternalC8DB<E>, D extends Inte
             @Override
             public Collection<String> deserialize(final Response response) throws VPackException {
                 final VPackSlice result = response.getBody().get(C8ResponseField.RESULT);
-                try {
-                    return new ObjectMapper().readValue(result.getAsString(), new TypeReference<Collection<String>>() {
-                    });
-                } catch (IOException e) {
-                    throw new C8DBException(e.getMessage());
-                }
+                return util().deserialize(result, new Type<Collection<String>>() {
+                }.getType());
             }
         };
     }
 
-    protected Request skipMessagesRequest(final String subscriptionName, final int numberOfMessages,
-            final boolean isLocal) {
+    protected Request expireMessagesRequest(int expireTimeInSeconds) {
         final Request request = request(db.tenant(), db.name(), RequestType.POST, PATH_API_STREAMS, name,
-                "subscription", subscriptionName, "skip", Integer.toString(numberOfMessages));
-        if (isLocal) {
-            request.putQueryParam("local", isLocal);
-        }
+                "expiry", Integer.toString(expireTimeInSeconds));
         return request;
     }
 
-    protected Request skipAllMessagesRequest(final String subscriptionName, final boolean isLocal) {
-        final Request request = request(db.tenant(), db.name(), RequestType.POST, PATH_API_STREAMS, name,
-                "subscription", subscriptionName, "skip_all");
-        if (isLocal) {
-            request.putQueryParam("local", isLocal);
-        }
-        return request;
-    }
-
-    protected Request resetCursorRequest(final String subscriptionName, final int timestamp, final boolean isLocal) {
-        final Request request = request(db.tenant(), db.name(), RequestType.POST, PATH_API_STREAMS, name,
-                "subscription", subscriptionName, "resetcursor", Integer.toString(timestamp));
-        if (isLocal) {
-            request.putQueryParam("local", isLocal);
-        }
-        return request;
-    }
-
-    protected Request resetCursorRequest(final String subscriptionName, final boolean isLocal) {
-        final Request request = request(db.tenant(), db.name(), RequestType.POST, PATH_API_STREAMS, name,
-                "subscription", subscriptionName, "resetcursor");
-        if (isLocal) {
-            request.putQueryParam("local", isLocal);
-        }
-        return request;
-    }
-
-    protected Request expireMessagesRequest(String subscriptionName, int expireTimeInSeconds, boolean isLocal) {
-        final Request request = request(db.tenant(), db.name(), RequestType.POST, PATH_API_STREAMS, name,
-                "subscription", subscriptionName, "expireMessages", Integer.toString(expireTimeInSeconds));
-        if (isLocal) {
-            request.putQueryParam("local", isLocal);
-        }
-        return request;
-    }
-
-    protected Request deleteSubscriptionRequest(String subscriptionName, boolean isLocal) {
+    protected Request deleteSubscriptionRequest(String subscriptionName) {
         final Request request = request(db.tenant(), db.name(), RequestType.DELETE, PATH_API_STREAMS, name,
-                "subscription", subscriptionName);
-        if (isLocal) {
-            request.putQueryParam("local", isLocal);
-        }
+                "subscriptions", subscriptionName);
         return request;
     }
 }

--- a/src/main/java/com/c8db/internal/InternalC8Variables.java
+++ b/src/main/java/com/c8db/internal/InternalC8Variables.java
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2022 Macrometa Corp All rights reserved.
+ */
+package com.c8db.internal;
+
+public class InternalC8Variables {
+
+    public static final String GLOBAL_STREAM_PREFIX = "c8globals.";
+    public static final String LOCAL_STREAM_PREFIX = "c8locals.";
+
+}

--- a/src/test/java/com/c8db/C8StreamTest.java
+++ b/src/test/java/com/c8db/C8StreamTest.java
@@ -43,7 +43,7 @@ import com.c8db.entity.C8StreamStatisticsEntity;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class C8StreamTest extends BaseTest {
 
-    private static final String STREAM_NAME = "dbCollectionTest";
+    private static final String STREAM_NAME = "c8globals.dbCollectionTest";
 
     public C8StreamTest(final Builder builder) {
         super(builder);
@@ -63,32 +63,28 @@ public class C8StreamTest extends BaseTest {
 
     @Test
     public void getBacklog() {
-        C8StreamBacklogEntity backlog = db.stream(STREAM_NAME).getBacklog(false);
+        C8StreamBacklogEntity backlog = db.stream(STREAM_NAME).getBacklog();
         assertThat(backlog, is(notNullValue()));
         assertThat(backlog.getTopicName().contains(STREAM_NAME), is(true));
     }
 
     @Test
     public void getStreamStatistics() {
-        C8StreamStatisticsEntity statistics = db.stream("_polog").getStatistics(false);
+        C8StreamStatisticsEntity statistics = db.stream("_polog").getStatistics();
         assertThat(statistics, is(notNullValue()));
     }
     
     @Ignore
     @Test
     public void streamsTest() {
-        C8Stream stream = db.stream("test");
+        C8Stream stream = db.stream("c8globals.test");
         Collection<C8StreamEntity> streams = db.getPersistentStreams(null);
-        stream.getBacklog(false);
-        stream.expireMessagesInSeconds("c8gui_51469", 10, true);
-        Collection<String> subs = stream.getSubscriptions(true);
-        
-        stream.resetCursorToTimestamp("c8gui_51469", (int) System.currentTimeMillis(), true);
-        stream.skipMessages("c8gui_51469", 2, true);
-        stream.skipAllMessages("c8gui_51469", true);
-       // stream.resetCursor("c8gui_51469", true);
-        stream.deleteSubscription("c8gui_51469", false);
-        stream.terminate(true);
+        stream.getBacklog();
+        stream.expireMessagesInSeconds(10);
+        Collection<String> subs = stream.getSubscriptions();
+
+        stream.deleteSubscription("c8gui_51469");
+        stream.delete();
     }
     
     


### PR DESCRIPTION
Streams methods should be the same as an official Streams API.
Some old methods were removed like `skipMessages`, `skipAllMessages`,  `resetCursorToTimestamp`, `resetCursor`.
Added `isLocal` property for methods that use on tenants level(namespace level).

