### PR TITLE
CEP-216 Added batchSize and TTL for c8db Cursor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.23-SNAPSHOT</version>
+    <version>1.1.22-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.22</version>
+    <version>1.1.23-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.22</tag>
+        <tag>c84j-1.1.21</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.21-SNAPSHOT</version>
+    <version>1.1.21</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.18-SNAPSHOT</tag>
+        <tag>c84j-1.1.21</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.22-SNAPSHOT</version>
+    <version>1.1.22</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.21</tag>
+        <tag>c84j-1.1.22</tag>
     </scm>
 
     <organization>

--- a/src/main/java/com/c8db/model/C8qlQueryOptions.java
+++ b/src/main/java/com/c8db/model/C8qlQueryOptions.java
@@ -32,6 +32,8 @@ public class C8qlQueryOptions implements Serializable {
     private Boolean cache;
     private Options options;
     private VPackSlice bindVars;
+    private Long batchSize;
+    private Long ttl;
 
     public C8qlQueryOptions() {
         super();
@@ -133,6 +135,32 @@ public class C8qlQueryOptions implements Serializable {
     public C8qlQueryOptions rules(final Collection<String> rules) {
         getOptions().getOptimizer().rules = rules;
         return this;
+    }
+
+    /**
+     * @param batchSize the batchsize of the result to be processed by the cursor
+     * @return options
+     */
+    public C8qlQueryOptions batchSize(final Long batchSize) {
+        this.batchSize = batchSize;
+        return this;
+    }
+
+    /**
+     * @param ttl the time-to-live for the cursor
+     * @return options
+     */
+    public C8qlQueryOptions ttl(final Long ttl) {
+        this.ttl = ttl;
+        return this;
+    }
+
+    public Long getBatchSize() {
+        return batchSize;
+    }
+
+    public Long getTtl() {
+        return ttl;
     }
 
     private Options getOptions() {

--- a/src/main/java/com/c8db/model/C8qlQueryOptions.java
+++ b/src/main/java/com/c8db/model/C8qlQueryOptions.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modifications copyright (c) 2022 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.model;


### PR DESCRIPTION
**Motivation:**
When reading a large chunk of data, the c8db cursor expires with the error 
**_Exception in thread "main" com.c8db.C8DBException: Response: 404, Error: 1600 - cursor not found_**

This happens because of the default batchSize = 100 and ttl = 30 seconds.
We need to have properties in c84j which allows custom batchSize and ttl to be used for creating cursor.

This PR contains implementation for [CEP-216](https://macrometa.atlassian.net/browse/CEP-216) . The implementation is for enabling the support for creating c8db cursor with custom **batchSize** and **ttl**.

The required cursor can be created as -

`final C8Cursor<Map> c8Cursor = database.query(query, options, type);`
where options contains the custom **batchSize** and **ttl**.

**How this has been Tested ?**
This implementation is tested by writing a test-utility class locally. (as mentioned in [CEP-216](https://macrometa.atlassian.net/browse/CEP-216))