### PR TITLE
CEP-291: Add cpu per worker and logs limits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.23-SNAPSHOT</version>
+    <version>1.1.23</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.21</tag>
+        <tag>c84j-1.1.23</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.23</version>
+    <version>1.1.24-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.23</tag>
+        <tag>c84j-1.1.21</tag>
     </scm>
 
     <organization>

--- a/src/main/java/com/c8db/entity/LimitsEntity.java
+++ b/src/main/java/com/c8db/entity/LimitsEntity.java
@@ -66,5 +66,7 @@ public class LimitsEntity implements Entity {
 		private int maxWorkersCpuSecondsPerMinute;
 		private int maxWorkersThroughputInMBPerMinute;
 		private int maxWorkersThroughputOutMBPerMinute;
+		private int maxCpuSecondsPerMinutePerWorker;
+		private int maxLogsLengthKBPerMinutePerWorker;
 	}
 }


### PR DESCRIPTION
Added properties `maxCpuSecondsPerMinutePerWorker` and `maxLogsLengthKBPerMinutePerWorker` to LimitsEntity
It needs for usage in limits in `c8cep`