### PR TITLE
Added support for c8cep cursor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,12 +208,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <!--<scope>provided</scope-->
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <!--<scope>provided</scope>-->
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -208,12 +208,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <scope>provided</scope>
+            <!--<scope>provided</scope-->
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <scope>provided</scope>
+            <!--<scope>provided</scope>-->
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>

--- a/src/main/java/com/c8db/C8Database.java
+++ b/src/main/java/com/c8db/C8Database.java
@@ -697,4 +697,7 @@ public interface C8Database extends C8SerializationAccessor {
      */
     C8Dynamo dynamo(final String tableName);
 
+    public <T> C8Cursor<T> executeUserQuery(final String query, final Map<String, Object> bindVars,
+                                            C8qlQueryOptions options, final Class<T> type);
+
 }

--- a/src/main/java/com/c8db/C8Database.java
+++ b/src/main/java/com/c8db/C8Database.java
@@ -322,6 +322,24 @@ public interface C8Database extends C8SerializationAccessor {
     <T> C8Cursor<T> cursor(String cursorId, Class<T> type) throws C8DBException;
 
     /**
+     * Performs a database query using the given {@code query} and {@code bindVars},
+     * then returns a new {@code ArangoCursor} instance for the result list.
+     *
+     * @param query    An AQL query string
+     * @param bindVars key/value pairs defining the variables to bind the query to
+     * @param type     The type of the result (POJO class, VPackSlice, String for
+     *                 JSON, or Collection/List/Map)
+     * @param requestSource a placeholder that represents the source of the request
+     * @return cursor of the results
+     * @throws C8DBException
+     * @see <a href=
+     * "https://docs.arangodb.com/current/HTTP/AqlQueryCursor/AccessingCursors.html#create-cursor">API
+     * Documentation</a>
+     */
+    <T> C8Cursor<T> query(final String query, final Map<String, Object> bindVars, final C8qlQueryOptions options,
+                          final Class<T> type, String requestSource) throws C8DBException;
+
+    /**
      * Explain an AQL query and return information about it
      *
      * @param query    the query which you want explained
@@ -713,8 +731,4 @@ public interface C8Database extends C8SerializationAccessor {
      * @return C8Dynamo handler
      */
     C8Dynamo dynamo(final String tableName);
-
-    public <T> C8Cursor<T> executeUserQuery(final String query, final Map<String, Object> bindVars,
-                                            C8qlQueryOptions options, final Class<T> type);
-
 }

--- a/src/main/java/com/c8db/Restql.java
+++ b/src/main/java/com/c8db/Restql.java
@@ -19,6 +19,7 @@ package com.c8db;
 
 import com.c8db.entity.UserQueryEntity;
 import com.c8db.entity.UserQueryOptions;
+import com.c8db.model.C8qlQueryOptions;
 
 import java.util.Collection;
 import java.util.Map;
@@ -97,6 +98,7 @@ public interface Restql extends C8SerializationAccessor {
     <T> C8Cursor<T> executeUserQueryByUserNameAndName(String userName, String name, Map<String, Object> bindVars,
                                                       Class<T> type);
 
+
     /**
      * Fetches all user queries associated with the current user
      *
@@ -113,5 +115,8 @@ public interface Restql extends C8SerializationAccessor {
      * @userName userName
      */
     Collection<UserQueryEntity> getUserQueries(final String userName) throws C8DBException;
+
+    public <T> C8Cursor<T> executeUserQueryByUserNameAndName(final String query, final Map<String, Object> bindVars,
+                                                             C8qlQueryOptions options, final Class<T> type);
 
 }

--- a/src/main/java/com/c8db/Restql.java
+++ b/src/main/java/com/c8db/Restql.java
@@ -115,8 +115,4 @@ public interface Restql extends C8SerializationAccessor {
      * @userName userName
      */
     Collection<UserQueryEntity> getUserQueries(final String userName) throws C8DBException;
-
-    public <T> C8Cursor<T> executeUserQueryByUserNameAndName(final String query, final Map<String, Object> bindVars,
-                                                             C8qlQueryOptions options, final Class<T> type);
-
 }

--- a/src/main/java/com/c8db/internal/C8DatabaseImpl.java
+++ b/src/main/java/com/c8db/internal/C8DatabaseImpl.java
@@ -186,6 +186,18 @@ public class C8DatabaseImpl extends InternalC8Database<C8DBImpl, C8ExecutorSync>
     }
 
     @Override
+    public <T> C8Cursor<T> query(final String query, final Map<String, Object> bindVars,
+                                 final C8qlQueryOptions options, final Class<T> type, String requestSource) throws C8DBException {
+
+        final Request request = queryRequest(query, bindVars, options,requestSource);
+        final HostHandle hostHandle = new HostHandle();
+        final CursorEntity result = executor.execute(request, CursorEntity.class, hostHandle);
+
+        return createCursor(result, type, options, hostHandle);
+
+    }
+
+    @Override
     public <T> C8Cursor<T> query(final String query, final Map<String, Object> bindVars, final Class<T> type)
             throws C8DBException {
         return query(query, bindVars, null, type);
@@ -439,16 +451,6 @@ public class C8DatabaseImpl extends InternalC8Database<C8DBImpl, C8ExecutorSync>
         final HostHandle hostHandle = new HostHandle();
         final CursorEntity result = executor.execute(request, CursorEntity.class, hostHandle);
         return createCursor(result, type, null, hostHandle);
-    }
-
-    @Override
-    public <T> C8Cursor<T> executeUserQuery(final String query, final Map<String, Object> bindVars,
-                                             C8qlQueryOptions options, final Class<T> type)
-            throws C8DBException {
-        final Request request = userQueryRequest(query, bindVars, options);
-        final HostHandle hostHandle = new HostHandle();
-        final CursorEntity result = executor.execute(request, CursorEntity.class, hostHandle);
-        return createCursor(result, type, options, hostHandle);
     }
 
     @Override

--- a/src/main/java/com/c8db/internal/C8DatabaseImpl.java
+++ b/src/main/java/com/c8db/internal/C8DatabaseImpl.java
@@ -428,6 +428,16 @@ public class C8DatabaseImpl extends InternalC8Database<C8DBImpl, C8ExecutorSync>
     }
 
     @Override
+    public <T> C8Cursor<T> executeUserQuery(final String query, final Map<String, Object> bindVars,
+                                             C8qlQueryOptions options, final Class<T> type)
+            throws C8DBException {
+        final Request request = userQueryRequest(query, bindVars, options);
+        final HostHandle hostHandle = new HostHandle();
+        final CursorEntity result = executor.execute(request, CursorEntity.class, hostHandle);
+        return createCursor(result, type, options, hostHandle);
+    }
+
+    @Override
     public C8Event event() {
         return new C8EventImpl(this);
     }

--- a/src/main/java/com/c8db/internal/InternalC8Database.java
+++ b/src/main/java/com/c8db/internal/InternalC8Database.java
@@ -554,6 +554,7 @@ public abstract class InternalC8Database<A extends InternalC8DB<E>, E extends C8
     }
 
     protected Request userQueryRequest(final String userName, final String restqlName, final Map<String, Object> bindVars) {
+        System.out.println("BindVars in restql c84j = " + bindVars);
         final Request request = userName == null ?
                 request(tenant, name, RequestType.POST, PATH_API_USER_QUERIES, "execute", "root", restqlName)
                 : request(tenant, name, RequestType.POST, PATH_API_USER_QUERIES, "execute", userName, restqlName);
@@ -563,6 +564,8 @@ public abstract class InternalC8Database<A extends InternalC8DB<E>, E extends C8
 
     protected Request userQueryRequest(final String query, final Map<String, Object> bindVars,
                                    final C8qlQueryOptions options) {
+        System.out.println("Executing user query request");
+        System.out.println("BindVars in db c84j = " + bindVars);
         final C8qlQueryOptions opt = options != null ? options : new C8qlQueryOptions();
         final Request request = request(tenant, name, RequestType.POST, PATH_API_CURSOR);
         request.setBody(

--- a/src/main/java/com/c8db/internal/InternalC8Database.java
+++ b/src/main/java/com/c8db/internal/InternalC8Database.java
@@ -566,6 +566,7 @@ public abstract class InternalC8Database<A extends InternalC8DB<E>, E extends C8
         Request request;
         boolean isParameterized = query.contains("@") ? true : false;
         if(isParameterized) {
+            System.out.println("isParameterized = " + isParameterized);
             Map<String, Object> bindVarMap;
             if (bindVars.containsKey("bindVars")) {
                 bindVarMap = (HashMap) bindVars.get("bindVars");
@@ -575,6 +576,7 @@ public abstract class InternalC8Database<A extends InternalC8DB<E>, E extends C8
             request = request(tenant, name, RequestType.POST, PATH_API_CURSOR)
                     .setBody(util().serialize(OptionsBuilder.build(options, query, util().serialize(bindVarMap))));
         } else {
+            System.out.println("isParameterized = " + isParameterized);
             request = request(tenant, name, RequestType.POST, PATH_API_CURSOR)
                     .setBody(util().serialize(OptionsBuilder.build(options, query, bindVars)));
         }

--- a/src/main/java/com/c8db/internal/InternalC8Database.java
+++ b/src/main/java/com/c8db/internal/InternalC8Database.java
@@ -563,8 +563,14 @@ public abstract class InternalC8Database<A extends InternalC8DB<E>, E extends C8
 
     protected Request queryRequest(final String query, final Map<String, Object> bindVars,
                                    final C8qlQueryOptions options, String type) {
+        Map<String, Object> bindVarMap;
+        if(bindVars.containsKey("bindVars")) {
+            bindVarMap = (HashMap) bindVars.get("bindVars");
+        } else {
+            bindVarMap = new HashMap<>();
+        }
         final Request request = request(tenant, name, RequestType.POST, PATH_API_CURSOR)
-                .setBody(util().serialize(OptionsBuilder.build(options, query, bindVars == null ? new HashMap<>() : bindVars)));
+                .setBody(util().serialize(OptionsBuilder.build(options, query, util().serialize(bindVarMap))));
         return request;
     }
 }

--- a/src/main/java/com/c8db/internal/InternalC8Database.java
+++ b/src/main/java/com/c8db/internal/InternalC8Database.java
@@ -561,11 +561,10 @@ public abstract class InternalC8Database<A extends InternalC8DB<E>, E extends C8
         return request;
     }
 
-    protected Request userQueryRequest(final String query, final Map<String, Object> bindVars,
-                                   final C8qlQueryOptions options) {
-        final Request request = request(tenant, name, RequestType.POST, PATH_API_CURSOR);
-        request.setBody(util().serialize(OptionsBuilder.build(options, query,
-                bindVars == null ? new HashMap<>() : bindVars)));
+    protected Request queryRequest(final String query, final Map<String, Object> bindVars,
+                                   final C8qlQueryOptions options, String type) {
+        final Request request = request(tenant, name, RequestType.POST, PATH_API_CURSOR)
+                .setBody(util().serialize(OptionsBuilder.build(options, query, bindVars == null ? new HashMap<>() : bindVars)));
         return request;
     }
 }

--- a/src/main/java/com/c8db/internal/InternalC8Database.java
+++ b/src/main/java/com/c8db/internal/InternalC8Database.java
@@ -566,7 +566,6 @@ public abstract class InternalC8Database<A extends InternalC8DB<E>, E extends C8
         Request request;
         boolean isParameterized = query.contains("@") ? true : false;
         if(isParameterized) {
-            System.out.println("isParameterized = " + isParameterized);
             Map<String, Object> bindVarMap;
             if (bindVars.containsKey("bindVars")) {
                 bindVarMap = (HashMap) bindVars.get("bindVars");
@@ -576,7 +575,6 @@ public abstract class InternalC8Database<A extends InternalC8DB<E>, E extends C8
             request = request(tenant, name, RequestType.POST, PATH_API_CURSOR)
                     .setBody(util().serialize(OptionsBuilder.build(options, query, util().serialize(bindVarMap))));
         } else {
-            System.out.println("isParameterized = " + isParameterized);
             request = request(tenant, name, RequestType.POST, PATH_API_CURSOR)
                     .setBody(util().serialize(OptionsBuilder.build(options, query, bindVars)));
         }

--- a/src/main/java/com/c8db/internal/InternalC8Database.java
+++ b/src/main/java/com/c8db/internal/InternalC8Database.java
@@ -562,15 +562,22 @@ public abstract class InternalC8Database<A extends InternalC8DB<E>, E extends C8
     }
 
     protected Request queryRequest(final String query, final Map<String, Object> bindVars,
-                                   final C8qlQueryOptions options, String type) {
-        Map<String, Object> bindVarMap;
-        if(bindVars.containsKey("bindVars")) {
-            bindVarMap = (HashMap) bindVars.get("bindVars");
+                                   final C8qlQueryOptions options, String requestSource) {
+        Request request;
+        boolean isParameterized = query.contains("@") ? true : false;
+        if(isParameterized) {
+            Map<String, Object> bindVarMap;
+            if (bindVars.containsKey("bindVars")) {
+                bindVarMap = (HashMap) bindVars.get("bindVars");
+            } else {
+                bindVarMap = new HashMap<>();
+            }
+            request = request(tenant, name, RequestType.POST, PATH_API_CURSOR)
+                    .setBody(util().serialize(OptionsBuilder.build(options, query, util().serialize(bindVarMap))));
         } else {
-            bindVarMap = new HashMap<>();
+            request = request(tenant, name, RequestType.POST, PATH_API_CURSOR)
+                    .setBody(util().serialize(OptionsBuilder.build(options, query, bindVars)));
         }
-        final Request request = request(tenant, name, RequestType.POST, PATH_API_CURSOR)
-                .setBody(util().serialize(OptionsBuilder.build(options, query, util().serialize(bindVarMap))));
         return request;
     }
 }

--- a/src/main/java/com/c8db/internal/InternalC8Database.java
+++ b/src/main/java/com/c8db/internal/InternalC8Database.java
@@ -511,4 +511,13 @@ public abstract class InternalC8Database<A extends InternalC8DB<E>, E extends C8
         return request;
     }
 
+    protected Request userQueryRequest(final String query, final Map<String, Object> bindVars,
+                                   final C8qlQueryOptions options) {
+        final C8qlQueryOptions opt = options != null ? options : new C8qlQueryOptions();
+        final Request request = request(tenant, name, RequestType.POST, PATH_API_CURSOR);
+        request.setBody(
+                util().serialize(OptionsBuilder.build(opt, query,
+                        util().serialize(bindVars != null ? bindVars :  new HashMap<String, Object>()))));
+        return request;
+    }
 }

--- a/src/main/java/com/c8db/internal/InternalC8Database.java
+++ b/src/main/java/com/c8db/internal/InternalC8Database.java
@@ -554,7 +554,6 @@ public abstract class InternalC8Database<A extends InternalC8DB<E>, E extends C8
     }
 
     protected Request userQueryRequest(final String userName, final String restqlName, final Map<String, Object> bindVars) {
-        System.out.println("BindVars in restql c84j = " + bindVars);
         final Request request = userName == null ?
                 request(tenant, name, RequestType.POST, PATH_API_USER_QUERIES, "execute", "root", restqlName)
                 : request(tenant, name, RequestType.POST, PATH_API_USER_QUERIES, "execute", userName, restqlName);
@@ -564,13 +563,9 @@ public abstract class InternalC8Database<A extends InternalC8DB<E>, E extends C8
 
     protected Request userQueryRequest(final String query, final Map<String, Object> bindVars,
                                    final C8qlQueryOptions options) {
-        System.out.println("Executing user query request");
-        System.out.println("BindVars in db c84j = " + bindVars);
-        final C8qlQueryOptions opt = options != null ? options : new C8qlQueryOptions();
         final Request request = request(tenant, name, RequestType.POST, PATH_API_CURSOR);
-        request.setBody(
-                util().serialize(OptionsBuilder.build(opt, query,
-                        util().serialize(bindVars != null ? bindVars :  new HashMap<String, Object>()))));
+        request.setBody(util().serialize(OptionsBuilder.build(options, query,
+                bindVars == null ? new HashMap<>() : bindVars)));
         return request;
     }
 }

--- a/src/main/java/com/c8db/internal/RestqlImpl.java
+++ b/src/main/java/com/c8db/internal/RestqlImpl.java
@@ -10,6 +10,7 @@ import com.c8db.C8DBException;
 import com.c8db.Restql;
 import com.c8db.entity.UserQueryEntity;
 import com.c8db.entity.UserQueryOptions;
+import com.c8db.model.C8qlQueryOptions;
 
 import java.util.Collection;
 import java.util.Map;
@@ -50,6 +51,12 @@ public class RestqlImpl extends InternalRestql<C8DBImpl, C8DatabaseImpl, C8Execu
     @Override
     public <T> C8Cursor<T> executeUserQueryByUserNameAndName(final String userName, final String name, final Map<String, Object> bindVars, Class<T> type) {
         return db().executeUserQuery(userName, name, bindVars, type);
+    }
+
+    @Override
+    public <T> C8Cursor<T> executeUserQueryByUserNameAndName(final String query, final Map<String, Object> bindVars,
+                                                             C8qlQueryOptions options, final Class<T> type) {
+        return db().executeUserQuery(query, bindVars, options, type);
     }
 
     @Override

--- a/src/main/java/com/c8db/internal/RestqlImpl.java
+++ b/src/main/java/com/c8db/internal/RestqlImpl.java
@@ -54,12 +54,6 @@ public class RestqlImpl extends InternalRestql<C8DBImpl, C8DatabaseImpl, C8Execu
     }
 
     @Override
-    public <T> C8Cursor<T> executeUserQueryByUserNameAndName(final String query, final Map<String, Object> bindVars,
-                                                             C8qlQueryOptions options, final Class<T> type) {
-        return db().executeUserQuery(query, bindVars, options, type);
-    }
-
-    @Override
     public Collection<UserQueryEntity> getUserQueries() throws C8DBException {
         return executor.execute(getUserQueriesRequest(), getUserQueriesResponseDeserializer());
     }

--- a/src/main/java/com/c8db/model/C8qlQueryOptions.java
+++ b/src/main/java/com/c8db/model/C8qlQueryOptions.java
@@ -20,6 +20,7 @@ package com.c8db.model;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Map;
 
 import com.arangodb.velocypack.VPackSlice;
 
@@ -36,9 +37,21 @@ public class C8qlQueryOptions implements Serializable {
     private VPackSlice bindVars;
     private Long batchSize;
     private Long ttl;
+    private Map<String, Object> bindVarMap;
 
     public C8qlQueryOptions() {
         super();
+    }
+
+    public C8qlQueryOptions(C8qlQueryOptions queryOptions) {
+       this.count = queryOptions.count;
+       this.query = queryOptions.query;
+       this.cache = queryOptions.cache;
+       this.options = queryOptions.options;
+       this.bindVars = queryOptions.bindVars;
+       this.batchSize = queryOptions.batchSize;
+       this.ttl = queryOptions.ttl;
+       this.bindVarMap = queryOptions.bindVarMap;
     }
 
     public Boolean getCount() {
@@ -85,6 +98,11 @@ public class C8qlQueryOptions implements Serializable {
      */
     protected C8qlQueryOptions bindVars(final VPackSlice bindVars) {
         this.bindVars = bindVars;
+        return this;
+    }
+
+    protected C8qlQueryOptions bindVarsMap(final Map<String, Object> bindVarMap) {
+        this.bindVarMap = bindVarMap;
         return this;
     }
 

--- a/src/main/java/com/c8db/model/OptionsBuilder.java
+++ b/src/main/java/com/c8db/model/OptionsBuilder.java
@@ -62,6 +62,10 @@ public class OptionsBuilder {
         return options.query(query).bindVars(bindVars);
     }
 
+    public static C8qlQueryOptions build(final C8qlQueryOptions options, final String query, final Map<String, Object> bindVars) {
+        return options.query(query).bindVarsMap(bindVars);
+    }
+
     public static C8qlQueryExplainOptions build(final C8qlQueryExplainOptions options, final String query,
             final VPackSlice bindVars) {
         return options.query(query).bindVars(bindVars);


### PR DESCRIPTION
This PR contains changes required to fix [CEP-216](https://macrometa.atlassian.net/browse/CEP-216).

### Motivation : 
Currently , the **c8cep** uses the **restql** APIs to create cursor, which does not support **ttl** and **batch-size**. We need a way to implement cursor so that the cursor remains active until all records are fetched from the source.

### Solution:
Added an overloaded method for **query()** present in C8Database.java class, which internally calls the **cursor** API (which supports **ttl** and **batch-size**) to handle the request from c8cep.