### PR TITLE
[C84J-13] Provide tenant as input to fetchSecret

### DIFF
--- a/src/main/java/com/c8db/SecretProvider.java
+++ b/src/main/java/com/c8db/SecretProvider.java
@@ -22,7 +22,9 @@ public interface SecretProvider {
     /**
      * Retrieves a secret to communicate with the server.
      *
+     * @param tenant for which tenant to fetch the secret
+     * @param user   for which user to fetch the secret
      * @return a valid secrete
      */
-    String fetchSecret();
+    String fetchSecret(String tenant, String user);
 }

--- a/src/main/java/com/c8db/internal/C8RemoteSecretProvider.java
+++ b/src/main/java/com/c8db/internal/C8RemoteSecretProvider.java
@@ -17,6 +17,8 @@ import com.c8db.velocystream.Response;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -48,14 +50,15 @@ public class C8RemoteSecretProvider implements SecretProvider {
     /**
      * Retrieve a token by talking to auth endpoint of c8 service.
      *
+     * @param tenant not used
      * @return a secret token in JWT format.
      */
     @Override
-    public String fetchSecret() {
+    public String fetchSecret(String tenant, String user) {
         String authUrl = RequestUtils.buildBaseUrl(authHost, useSsl) + "/_open/auth";
         Map<String, String> credentials = new HashMap<>();
 
-        credentials.put("username", username);
+        credentials.put("username", StringUtils.isNotEmpty(user) ? user : username);
         credentials.put("password", new String(password));
         credentials.put("email", email);
         final HttpRequestBase authHttpRequest = RequestUtils.buildHttpRequestBase(

--- a/src/main/java/com/c8db/internal/http/HttpConnection.java
+++ b/src/main/java/com/c8db/internal/http/HttpConnection.java
@@ -225,7 +225,7 @@ public class HttpConnection implements Connection {
                 LOGGER.debug("Using API Key for authentication.");
                 httpRequest.addHeader(HttpHeaders.AUTHORIZATION, "apikey " + apiKey);
             } else if (jwt == null) { //Generate JWT using user credentials if jwt and apikey are absent
-                addJWT();
+                addJWT(request.getTenant());
                 LOGGER.debug("Using JWT for authentication.");
                 httpRequest.addHeader(HttpHeaders.AUTHORIZATION, "bearer " + jwt);
             } else { //Add Header when JWT is provided
@@ -247,7 +247,7 @@ public class HttpConnection implements Connection {
         } catch (C8DBException ex) {
             if (ex.getResponseCode().equals(401)) {
                 // jwt might have expired refresh it
-                addJWT();
+                addJWT(request.getTenant());
                 httpRequest.removeHeaders(HttpHeaders.AUTHORIZATION);
                 httpRequest.addHeader(HttpHeaders.AUTHORIZATION, "bearer " + jwt);
                 response = ResponseUtils.buildResponse(util, client.execute(httpRequest), contentType);
@@ -281,7 +281,7 @@ public class HttpConnection implements Connection {
             } catch (Exception e) {
                 if (e instanceof C8DBException && ((C8DBException) e).getResponseCode().equals(401)) {
                     // jwt might have expired refresh it
-                    addJWT();
+                    addJWT(request.getTenant());
                     httpRequest.removeHeaders(HttpHeaders.AUTHORIZATION);
                     httpRequest.addHeader(HttpHeaders.AUTHORIZATION, "bearer " + jwt);
                 }
@@ -292,8 +292,8 @@ public class HttpConnection implements Connection {
         return response;
     }
 
-    private synchronized void addJWT() {
-        String secret = secretProvider.fetchSecret();
+    private synchronized void addJWT(String tenant) {
+        String secret = secretProvider.fetchSecret(tenant, user);
         setJwt(secret);
     }
 


### PR DESCRIPTION
Most implementations of SecretProvider requires tenant as input to fetchSecret method. So the tenant for token request can be changed dynamically after initializing the driver.