### PR TITLE
CEP-397: Add Compute API and response limit

### DIFF
--- a/src/main/java/com/c8db/C8Compute.java
+++ b/src/main/java/com/c8db/C8Compute.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2022 Macrometa Corp All rights reserved.
+ */
+package com.c8db;
+
+import com.c8db.entity.FxEntity;
+import com.c8db.entity.FxMetadataEntity;
+import com.c8db.model.FxReadOptions;
+
+import java.util.Collection;
+import java.util.Map;
+
+public interface C8Compute {
+
+    /**
+     * Fetches a list of all functions.
+     *
+     * @return
+     * @throws C8DBException
+     */
+    Collection<FxEntity> getFunctions() throws C8DBException;
+
+    /**
+     * Fetches a list of all functions.
+     *
+     * @param options - filter by FxReadOptions instance
+     * @return
+     * @throws C8DBException
+     */
+    Collection<FxEntity> getFunctions(final FxReadOptions options) throws C8DBException;
+
+    /**
+     * Get information about function worker.
+     *
+     * @return - result as FxEntity object
+     * @throws C8DBException
+     */
+    FxEntity getInfo(final String name) throws C8DBException;
+
+    /**
+     * Fetch information about a edge worker.
+     *
+     * @return - result as FxMetadataEntity object
+     * @throws C8DBException
+     */
+    FxMetadataEntity getMetadata() throws C8DBException;
+
+    /**
+     * Execute a function worker.
+     *
+     * @param name - name of function
+     * @param arguments - set parameters with arguments as a map
+     * @return - result of execution of a function.
+     * @throws C8DBException
+     */
+    Collection<Map<String, Object>> executeFunction(String name, Map<String, Object> arguments) throws C8DBException;
+}

--- a/src/main/java/com/c8db/C8ComputeImpl.java
+++ b/src/main/java/com/c8db/C8ComputeImpl.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2022 Macrometa Corp All rights reserved.
+ */
+package com.c8db;
+
+import com.c8db.entity.FxEntity;
+import com.c8db.entity.FxMetadataEntity;
+import com.c8db.internal.C8DBImpl;
+import com.c8db.internal.C8DatabaseImpl;
+import com.c8db.internal.C8ExecutorSync;
+import com.c8db.internal.InternalC8Compute;
+import com.c8db.model.FxReadOptions;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class C8ComputeImpl extends InternalC8Compute<C8DBImpl, C8DatabaseImpl, C8ExecutorSync> implements C8Compute {
+
+    public C8ComputeImpl(C8DatabaseImpl db) {
+        super(db);
+    }
+
+    @Override
+    public Collection<FxEntity> getFunctions() throws C8DBException {
+        return getFunctions(null);
+    }
+
+    @Override
+    public Collection<FxEntity> getFunctions(final FxReadOptions options) throws C8DBException {
+        return executor.execute(getFunctionsRequest(options), getFunctionsResponseDeserializer(), null, Service.C8FUNCTION);
+    }
+
+    @Override
+    public FxEntity getInfo(String name) throws C8DBException {
+        return executor.execute(getInfoRequest(name), getInfoResponseDeserializer(), null, Service.C8FUNCTION);
+    }
+
+    @Override
+    public FxMetadataEntity getMetadata() throws C8DBException {
+        return executor.execute(getMetadataRequest(), getMetadataResponseDeserializer(), null, Service.C8FUNCTION);
+    }
+
+    @Override
+    public Collection<Map<String, Object>> executeFunction(String name, Map<String, Object> arguments) throws C8DBException {
+        return executor.execute(executeFunctionRequest(name, arguments), executeFunctionResponseDeserializer(), null, Service.C8FUNCTION);
+    }
+}

--- a/src/main/java/com/c8db/C8DB.java
+++ b/src/main/java/com/c8db/C8DB.java
@@ -149,6 +149,17 @@ public interface C8DB extends C8SerializationAccessor {
         }
 
         /**
+         * Sets the response size in bytes.
+         *
+         * @param responseSizeLimit size in bytes
+         * @return {@link C8DB.Builder}
+         */
+        public Builder responseSizeLimit(final Integer responseSizeLimit) {
+            setResponseSizeLimit(responseSizeLimit);
+            return this;
+        }
+
+        /**
          * Sets the username to use for authentication.
          *
          * @param user the user in the database (default: {@code root})
@@ -621,6 +632,9 @@ public interface C8DB extends C8SerializationAccessor {
             if (hosts.get(Service.C8STREAMS).isEmpty()) {
                 hosts.get(Service.C8STREAMS).addAll(hosts.get(Service.C8DB));
             }
+            if (hosts.get(Service.C8FUNCTION).isEmpty()) {
+                hosts.get(Service.C8FUNCTION).addAll(hosts.get(Service.C8DB));
+            }
             final HostDescription auxHost = hosts.get(Service.C8DB).get(0);
             final VPack vpacker = vpackBuilder.serializeNullValues(false).build();
             final VPack vpackerNull = vpackBuilder.serializeNullValues(true).build();
@@ -642,7 +656,7 @@ public interface C8DB extends C8SerializationAccessor {
             if (protocol == null || Protocol.VST == protocol) {
                 connectionFactory = new VstConnectionFactorySync(host, timeout, connectionTtl, useSsl, sslContext);
             } else {
-                connectionFactory = new HttpConnectionFactory(timeout, user, password, secretProvider, email, jwtAuth, jwtToken, useSsl,
+                connectionFactory = new HttpConnectionFactory(timeout, responseSizeLimit, user, password, secretProvider, email, jwtAuth, jwtToken, useSsl,
                     sslContext, custom, protocol, connectionTtl, httpCookieSpec, apiKey, auxHost);
             }
             final Map<Service, Collection<Host>> hostsMatrix = createHostMatrix(max, connectionFactory);

--- a/src/main/java/com/c8db/C8Database.java
+++ b/src/main/java/com/c8db/C8Database.java
@@ -750,4 +750,10 @@ public interface C8Database extends C8SerializationAccessor {
      */
     C8Dynamo dynamo(final String tableName);
 
+    /**
+     * Returns a {@code C8Compute} instance.
+     * @return C8Compute handler
+     */
+    C8Compute compute();
+
 }

--- a/src/main/java/com/c8db/Service.java
+++ b/src/main/java/com/c8db/Service.java
@@ -7,6 +7,7 @@ package com.c8db;
 public enum Service {
 
     C8DB,
-    C8STREAMS
+    C8STREAMS,
+    C8FUNCTION
 
 }

--- a/src/main/java/com/c8db/entity/FxEntity.java
+++ b/src/main/java/com/c8db/entity/FxEntity.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2022 Macrometa Corp All rights reserved.
+ */
+package com.c8db.entity;
+
+import com.arangodb.velocypack.annotations.SerializedName;
+
+/**
+ * Class describes function worker
+ */
+public class FxEntity implements Entity {
+
+    @SerializedName("_id")
+    private String id;
+    @SerializedName("_key")
+    private String key;
+    @SerializedName("_rev")
+    private String rev;
+    private String activationStatus;
+    private long createdAt;
+    private long edgeWorkerId;
+    private String environment;
+    private String fabric;
+    private long lastModified;
+    private String name;
+    private String queryWorkerName;
+    private String queue;
+    private FxType type;
+    private String url;
+
+    public String getId() {
+        return id;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getRev() {
+        return rev;
+    }
+
+    public String getActivationStatus() {
+        return activationStatus;
+    }
+
+    public long getCreatedAt() {
+        return createdAt;
+    }
+
+    public long getEdgeWorkerId() {
+        return edgeWorkerId;
+    }
+
+    public String getEnvironment() {
+        return environment;
+    }
+
+    public String getFabric() {
+        return fabric;
+    }
+
+    public long getLastModified() {
+        return lastModified;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getQueryWorkerName() {
+        return queryWorkerName;
+    }
+
+    public String getQueue() {
+        return queue;
+    }
+
+    public FxType getType() {
+        return type;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/src/main/java/com/c8db/entity/FxMetadataEntity.java
+++ b/src/main/java/com/c8db/entity/FxMetadataEntity.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2022 Macrometa Corp All rights reserved.
+ */
+package com.c8db.entity;
+
+/**
+ * Class describes metadata of function worker.
+ */
+public class FxMetadataEntity implements Entity {
+
+    private String accessToken;
+    private String baseUri;
+    private String clientSecret;
+    private String clientToken;
+    private String contractId;
+    private String gdnApiKey;
+    private String gdnApiKeyName;
+    private String groupId;
+    private String hostName;
+    private String propertyId;
+    private String resourceTierId;
+    private FxType type;
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getBaseUri() {
+        return baseUri;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public String getClientToken() {
+        return clientToken;
+    }
+
+    public String getContractId() {
+        return contractId;
+    }
+
+    public String getGdnApiKey() {
+        return gdnApiKey;
+    }
+
+    public String getGdnApiKeyName() {
+        return gdnApiKeyName;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getHostName() {
+        return hostName;
+    }
+
+    public String getPropertyId() {
+        return propertyId;
+    }
+
+    public String getResourceTierId() {
+        return resourceTierId;
+    }
+
+    public FxType getType() {
+        return type;
+    }
+}

--- a/src/main/java/com/c8db/entity/FxType.java
+++ b/src/main/java/com/c8db/entity/FxType.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2022 Macrometa Corp All rights reserved.
+ */
+package com.c8db.entity;
+
+/**
+ * Class describes type of function worker.
+ */
+public enum FxType {
+
+    ALL,
+    AKAMAI,
+    MACROMETA
+
+}

--- a/src/main/java/com/c8db/internal/C8DatabaseImpl.java
+++ b/src/main/java/com/c8db/internal/C8DatabaseImpl.java
@@ -9,6 +9,8 @@ import com.c8db.C8Admin;
 import com.c8db.C8Alerts;
 import com.c8db.C8ApiKeys;
 import com.c8db.C8Collection;
+import com.c8db.C8Compute;
+import com.c8db.C8ComputeImpl;
 import com.c8db.C8Cursor;
 import com.c8db.C8Database;
 import com.c8db.C8Dynamo;
@@ -493,5 +495,10 @@ public class C8DatabaseImpl extends InternalC8Database<C8DBImpl, C8ExecutorSync>
     @Override
     public C8Dynamo dynamo(String tableName) {
         return new C8DynamoImpl(this, tableName);
+    }
+
+    @Override
+    public C8Compute compute() {
+        return new C8ComputeImpl(this);
     }
 }

--- a/src/main/java/com/c8db/internal/C8Defaults.java
+++ b/src/main/java/com/c8db/internal/C8Defaults.java
@@ -38,6 +38,7 @@ public final class C8Defaults {
     public static final String DEFAULT_DC_LIST = "tonchev-europe-west4,tonchev-europe-west1";
     public static final String DEFAULT_TENANT = "demo";
     public static final Integer DEFAULT_TIMEOUT = 0;
+    public static final Integer DEFAULT_RESPONSE_SIZE_LIMIT = 1024 * 1024;
     public static final String DEFAULT_USER = "root";
     public static final Boolean DEFAULT_USE_SSL = true;
     public static final Boolean DEFAULT_JWT_AUTH = true;

--- a/src/main/java/com/c8db/internal/InternalC8Compute.java
+++ b/src/main/java/com/c8db/internal/InternalC8Compute.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2021 Macrometa Corp All rights reserved.
+ */
+
+package com.c8db.internal;
+
+import com.arangodb.velocypack.Type;
+import com.arangodb.velocypack.VPackSlice;
+import com.arangodb.velocypack.exception.VPackException;
+import com.c8db.entity.FxEntity;
+import com.c8db.entity.FxMetadataEntity;
+import com.c8db.internal.C8Executor.ResponseDeserializer;
+import com.c8db.model.FxReadOptions;
+import com.c8db.velocystream.Request;
+import com.c8db.velocystream.RequestType;
+import com.c8db.velocystream.Response;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Internal request/response related functions.
+ */
+public abstract class InternalC8Compute<A extends InternalC8DB<E>, D extends InternalC8Database<A, E>, E extends C8Executor>
+    extends C8Executeable<E> {
+
+    protected static final String PATH_API_COMPUTE = "/_api/compute";
+    protected static final String PATH_API_FX = PATH_API_COMPUTE + "/fx";
+    protected static final String METADATA = "metadata";
+
+    private final D db;
+
+    public InternalC8Compute(D db) {
+        super(db.executor, db.util, db.context);
+        this.db = db;
+    }
+
+    protected Request getFunctionsRequest(final FxReadOptions options) {
+        final Request request = request(db.tenant(), db.name(), RequestType.GET, PATH_API_FX);
+        final FxReadOptions params = (options != null ? options : new FxReadOptions());
+        request.putQueryParam("type", params.getType().toString().toLowerCase());
+        return request;
+    }
+
+    protected ResponseDeserializer<Collection<FxEntity>> getFunctionsResponseDeserializer() {
+        return new ResponseDeserializer<Collection<FxEntity>>() {
+            @Override
+            public Collection<FxEntity> deserialize(final Response response) throws VPackException {
+                final VPackSlice result = response.getBody();
+                return util().deserialize(result, new Type<Collection<FxEntity>>() {
+                }.getType());
+            }
+        };
+    }
+
+    protected Request getInfoRequest(final String name) {
+        final Request request = request(db.tenant(), db.name(), RequestType.GET, PATH_API_FX, name);
+        return request;
+    }
+
+    protected ResponseDeserializer<FxEntity> getInfoResponseDeserializer() {
+        return new ResponseDeserializer<FxEntity>() {
+            @Override
+            public FxEntity deserialize(final Response response) throws VPackException {
+                final VPackSlice result = response.getBody();
+                Collection<FxEntity> entites = util().deserialize(result, new Type<Collection<FxEntity>>() {
+                }.getType());
+                return entites.isEmpty() ? null : entites.iterator().next();
+            }
+        };
+    }
+
+    protected Request getMetadataRequest() {
+        final Request request = request(db.tenant(), db.name(), RequestType.GET, PATH_API_FX, METADATA);
+        return request;
+    }
+
+    protected ResponseDeserializer<FxMetadataEntity> getMetadataResponseDeserializer() {
+        return new ResponseDeserializer<FxMetadataEntity>() {
+            @Override
+            public FxMetadataEntity deserialize(final Response response) throws VPackException {
+                final VPackSlice result = response.getBody();
+                return util().deserialize(result, new Type<FxMetadataEntity>() {
+                }.getType());
+            }
+        };
+    }
+
+    protected Request executeFunctionRequest(String name, Map<String, Object> arguments) {
+        final VPackSlice body = util().serialize(arguments);
+        final Request request = request(db.tenant(), db.name(), RequestType.POST, PATH_API_FX, "invoke", name);
+        request.putQueryParam("params", body.toString());
+        return request;
+    }
+
+    protected ResponseDeserializer<Collection<Map<String, Object>>> executeFunctionResponseDeserializer() {
+        return new ResponseDeserializer<Collection<Map<String, Object>>>() {
+            @Override
+            public Collection<Map<String, Object>> deserialize(final Response response) throws VPackException {
+                final VPackSlice result = response.getBody();
+                if (result.isArray()) {
+                    return util().deserialize(result, new Type<Collection<Map<String, Object>>>(){}.getType());
+                } else {
+                    return Arrays.asList(util().deserialize(result, new Type<Map<String, Object>>(){}.getType()));
+                }
+            }
+        };
+    }
+
+}

--- a/src/main/java/com/c8db/internal/InternalC8DBBuilder.java
+++ b/src/main/java/com/c8db/internal/InternalC8DBBuilder.java
@@ -66,6 +66,7 @@ public abstract class InternalC8DBBuilder {
     private static final String PROPERTY_KEY_HOST = "c8db.host";
     private static final String PROPERTY_KEY_PORT = "c8db.port";
     private static final String PROPERTY_KEY_TIMEOUT = "c8db.timeout";
+    private static final String PROPERTY_KEY_RESPONSE_SIZE_LIMIT = "c8db.responseSizeLimit";
     private static final String PROPERTY_KEY_USER = "c8db.user";
     private static final String PROPERTY_KEY_PASSWORD = "c8db.password";
     private static final String PROPERTY_KEY_EMAIL = "c8db.email";
@@ -85,6 +86,7 @@ public abstract class InternalC8DBBuilder {
     protected final Map<Service, List<HostDescription>> hosts;
     protected HostDescription host;
     protected Integer timeout;
+    protected Integer responseSizeLimit;
     protected String user;
     protected String password;
     protected String email;
@@ -148,6 +150,7 @@ public abstract class InternalC8DBBuilder {
         final int port = loadPort(properties, this.host.getPort());
         this.host = new HostDescription(host, port);
         timeout = loadTimeout(properties, timeout);
+        responseSizeLimit = loadMaxResponseSize(properties, responseSizeLimit);
         user = loadUser(properties, user);
         password = loadPassword(properties, password);
         email = loadEmail(properties, email);
@@ -182,6 +185,10 @@ public abstract class InternalC8DBBuilder {
 
     protected void setTimeout(final Integer timeout) {
         this.timeout = timeout;
+    }
+
+    protected void setResponseSizeLimit(final Integer responseSizeLimit) {
+        this.responseSizeLimit = responseSizeLimit;
     }
 
     protected void setUser(final String user) {
@@ -314,6 +321,11 @@ public abstract class InternalC8DBBuilder {
     private static Integer loadTimeout(final Properties properties, final Integer currentValue) {
         return Integer
                 .parseInt(getProperty(properties, PROPERTY_KEY_TIMEOUT, currentValue, C8Defaults.DEFAULT_TIMEOUT));
+    }
+
+    private static Integer loadMaxResponseSize(final Properties properties, final Integer currentValue) {
+        return Integer
+            .parseInt(getProperty(properties, PROPERTY_KEY_RESPONSE_SIZE_LIMIT, currentValue, C8Defaults.DEFAULT_RESPONSE_SIZE_LIMIT));
     }
 
     private static String loadUser(final Properties properties, final String currentValue) {

--- a/src/main/java/com/c8db/internal/http/HttpCommunication.java
+++ b/src/main/java/com/c8db/internal/http/HttpCommunication.java
@@ -82,7 +82,7 @@ public class HttpCommunication implements Closeable {
             while (true) {
                 try {
                     final HttpConnection connection = (HttpConnection) host.connection();
-                    final Response response = connection.execute(request);
+                    final Response response = connection.execute(request, service);
                     hostHandler.success();
                     hostHandler.confirm();
                     return response;

--- a/src/main/java/com/c8db/internal/http/HttpConnectionFactory.java
+++ b/src/main/java/com/c8db/internal/http/HttpConnectionFactory.java
@@ -32,23 +32,25 @@ public class HttpConnectionFactory implements ConnectionFactory {
 
     private final HttpConnection.Builder builder;
 
-    public HttpConnectionFactory(final Integer timeout, final String user, final String password, final String email,
-            final Boolean jwtAuth, final Boolean useSsl, final SSLContext sslContext, final C8Serialization util,
-            final Protocol protocol, final Long connectionTtl, String httpCookieSpec, final String jwtToken, final String apiKey,
+    public HttpConnectionFactory(final Integer timeout, final Integer responseSizeLimit, final String user,
+                                 final String password, final String email, final Boolean jwtAuth, final Boolean useSsl,
+                                 final SSLContext sslContext, final C8Serialization util, final Protocol protocol,
+                                 final Long connectionTtl, String httpCookieSpec, final String jwtToken, final String apiKey,
                                  final HostDescription auxiliaryHost) {
         super();
-        builder = new HttpConnection.Builder().timeout(timeout).user(user).password(password).email(email)
+        builder = new HttpConnection.Builder().timeout(timeout).responseSizeLimit(responseSizeLimit).user(user)
+                .password(password).email(email)
                 .jwtAuthEnabled(jwtAuth).useSsl(useSsl).sslContext(sslContext).serializationUtil(util)
                 .contentType(protocol).ttl(connectionTtl).httpCookieSpec(httpCookieSpec).jwt(jwtToken)
                 .apiKey(apiKey).auxHost(auxiliaryHost);
     }
 
-    public HttpConnectionFactory(final Integer timeout, final String user, final String password,
+    public HttpConnectionFactory(final Integer timeout, final Integer responseSizeLimit, final String user, final String password,
         SecretProvider secretProvider, final String email, final Boolean jwtAuth, final String jwtToken, final Boolean useSsl,
         final SSLContext sslContext, final C8Serialization util, final Protocol protocol, final Long connectionTtl,
         String httpCookieSpec, final String apiKey, final HostDescription auxiliaryHost) {
         super();
-        builder = new HttpConnection.Builder().timeout(timeout).secretProvider(secretProvider).email(email)
+        builder = new HttpConnection.Builder().timeout(timeout).responseSizeLimit(responseSizeLimit).secretProvider(secretProvider).email(email)
             .jwtAuthEnabled(jwtAuth).jwt(jwtToken).useSsl(useSsl).sslContext(sslContext).serializationUtil(util)
             .contentType(protocol).ttl(connectionTtl).httpCookieSpec(httpCookieSpec)
             .apiKey(apiKey).auxHost(auxiliaryHost).user(user).password(password);

--- a/src/main/java/com/c8db/internal/http/HttpRequestRetryHandler.java
+++ b/src/main/java/com/c8db/internal/http/HttpRequestRetryHandler.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2022 Macrometa Corp All rights reserved.
+ */
+package com.c8db.internal.http;
+
+import org.apache.http.MessageConstraintException;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+
+import javax.net.ssl.SSLException;
+import java.io.InterruptedIOException;
+import java.net.ConnectException;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+
+public class HttpRequestRetryHandler extends DefaultHttpRequestRetryHandler {
+
+    public HttpRequestRetryHandler() {
+        super(3, false,
+            Arrays.asList(InterruptedIOException.class, UnknownHostException.class,
+                ConnectException.class, SSLException.class, MessageConstraintException.class));
+    }
+}

--- a/src/main/java/com/c8db/internal/velocypack/VPackDeserializers.java
+++ b/src/main/java/com/c8db/internal/velocypack/VPackDeserializers.java
@@ -21,6 +21,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
 
+import com.c8db.entity.FxType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -137,6 +138,14 @@ public class VPackDeserializers {
         public Permissions deserialize(final VPackSlice parent, final VPackSlice vpack,
                 final VPackDeserializationContext context) throws VPackException {
             return Permissions.valueOf(vpack.getAsString().toUpperCase());
+        }
+    };
+
+    public static final VPackDeserializer<FxType> FX_TYPE = new VPackDeserializer<FxType>() {
+        @Override
+        public FxType deserialize(final VPackSlice parent, final VPackSlice vpack,
+                                  final VPackDeserializationContext context) throws VPackException {
+            return FxType.valueOf(vpack.getAsString().toUpperCase());
         }
     };
 

--- a/src/main/java/com/c8db/internal/velocypack/VPackDriverModule.java
+++ b/src/main/java/com/c8db/internal/velocypack/VPackDriverModule.java
@@ -29,6 +29,7 @@ import com.c8db.entity.BaseEdgeDocument;
 import com.c8db.entity.CollectionStatus;
 import com.c8db.entity.CollectionType;
 import com.c8db.entity.DocumentField;
+import com.c8db.entity.FxType;
 import com.c8db.entity.License;
 import com.c8db.entity.LogLevel;
 import com.c8db.entity.MinReplicationFactor;
@@ -79,6 +80,7 @@ public class VPackDriverModule implements VPackModule, VPackParserModule {
         context.registerDeserializer(License.class, VPackDeserializers.LICENSE);
         context.registerDeserializer(Permissions.class, VPackDeserializers.PERMISSIONS);
         context.registerDeserializer(QueryExecutionState.class, VPackDeserializers.QUERY_EXECUTION_STATE);
+        context.registerDeserializer(FxType.class, VPackDeserializers.FX_TYPE);
         context.registerDeserializer(ReplicationFactor.class, VPackDeserializers.REPLICATION_FACTOR);
         context.registerDeserializer(MinReplicationFactor.class, VPackDeserializers.MIN_REPLICATION_FACTOR);
     }

--- a/src/main/java/com/c8db/model/FxReadOptions.java
+++ b/src/main/java/com/c8db/model/FxReadOptions.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Macrometa Corp All rights reserved.
+ */
+
+package com.c8db.model;
+
+import com.c8db.entity.FxType;
+
+/**
+ * Read options for function worker
+ */
+public class FxReadOptions {
+
+    private FxType type = FxType.ALL;
+
+    public FxReadOptions() {
+        super();
+    }
+
+    public FxType getType() {
+        return type;
+    }
+
+    /**
+     * Set type of function.
+     *
+     * @param type - instance of `FxType` class.
+     * @return
+     */
+    public FxReadOptions type(final FxType type) {
+        this.type = type;
+        return this;
+    }
+}


### PR DESCRIPTION
The PR the same as https://github.com/Macrometacorp/c84j/pull/75 but for `master`

Added methods for Compute API
- Fetches a list of all functions. `getFunctions()`
- Get information about function worker. `getInfo(final String name)`
- Fetch information about a edge worker. `getMetadata()`
- Execute a function worker. `executeFunction(String name, Map<String, Object> arguments)`
- added response limit with default value is 1MB.