### PR TITLE
[1.1.25] CEP-397: Change path to FaaS Server to `_api/function/invoke`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.25.4</version>
+    <version>1.1.25.5-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.25.4</tag>
+        <tag>c84j-1.1.25.1</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.25.4-SNAPSHOT</version>
+    <version>1.1.25.4</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.25.1</tag>
+        <tag>c84j-1.1.25.4</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.25.1</tag>
+        <tag>c84j-1.1.25.2</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.25.2</tag>
+        <tag>c84j-1.1.25.1</tag>
     </scm>
 
     <organization>

--- a/src/main/java/com/c8db/internal/C8ComputeImpl.java
+++ b/src/main/java/com/c8db/internal/C8ComputeImpl.java
@@ -1,14 +1,13 @@
 /**
  * Copyright (c) 2022 Macrometa Corp All rights reserved.
  */
-package com.c8db;
+package com.c8db.internal;
 
+import com.c8db.C8Compute;
+import com.c8db.C8DBException;
+import com.c8db.Service;
 import com.c8db.entity.FxEntity;
 import com.c8db.entity.FxMetadataEntity;
-import com.c8db.internal.C8DBImpl;
-import com.c8db.internal.C8DatabaseImpl;
-import com.c8db.internal.C8ExecutorSync;
-import com.c8db.internal.InternalC8Compute;
 import com.c8db.model.FxReadOptions;
 
 import java.util.Collection;

--- a/src/main/java/com/c8db/internal/C8DatabaseImpl.java
+++ b/src/main/java/com/c8db/internal/C8DatabaseImpl.java
@@ -10,7 +10,6 @@ import com.c8db.C8Alerts;
 import com.c8db.C8ApiKeys;
 import com.c8db.C8Collection;
 import com.c8db.C8Compute;
-import com.c8db.C8ComputeImpl;
 import com.c8db.C8Cursor;
 import com.c8db.C8Database;
 import com.c8db.C8Dynamo;

--- a/src/main/java/com/c8db/internal/InternalC8Compute.java
+++ b/src/main/java/com/c8db/internal/InternalC8Compute.java
@@ -25,9 +25,9 @@ import java.util.Map;
 public abstract class InternalC8Compute<A extends InternalC8DB<E>, D extends InternalC8Database<A, E>, E extends C8Executor>
         extends C8Executeable<E> {
 
-    protected static final String PATH_API_COMPUTE = "/_api/compute";
-    protected static final String PATH_API_FX = PATH_API_COMPUTE + "/fx";
+    protected static final String PATH_API_FX = "/_api/function";
     protected static final String METADATA = "metadata";
+    protected static final String INVOKE = "invoke";
 
     private final D db;
 
@@ -89,7 +89,7 @@ public abstract class InternalC8Compute<A extends InternalC8DB<E>, D extends Int
 
     protected Request executeFunctionRequest(String name, Map<String, Object> arguments) {
         final VPackSlice body = util().serialize(arguments);
-        final Request request = request(db.tenant(), db.name(), RequestType.POST, PATH_API_FX, "invoke", name);
+        final Request request = request(db.tenant(), db.name(), RequestType.POST, PATH_API_FX, INVOKE, name);
         request.putQueryParam("params", body.toString());
         return request;
     }

--- a/src/main/java/com/c8db/internal/http/HttpConnection.java
+++ b/src/main/java/com/c8db/internal/http/HttpConnection.java
@@ -249,6 +249,11 @@ public class HttpConnection implements Connection {
             httpRequest.setHeader("Accept", "application/x-velocypack");
         }
         httpRequest.setHeader("x-gdn-tenantid", request.getTenant());
+        // TODO: it is temporal solution for FaaS server.
+        // "internalRequest" will be changed to encoded value to make sure that this call was made inside of cluster
+        if (StringUtils.isNotEmpty(System.getenv("C8_SVCUSER"))) {
+            httpRequest.setHeader("x-c8-requester", "internalRequest");
+        }
         addHeader(request, httpRequest);
         if (jwtAuthEnabled) {
             updateJWT();


### PR DESCRIPTION
Changed path to FaaS Server regarding new requirement by @Anurag Dwivedi :
We  need to call this api:
`_fabric/:fabric/_api/function/invoke/`
in place of the earlier one
`_fabric/_system/_api/compute/fx/invoke/`

@yehan-macrometa - this PR will be merged to `1.1.25` as you done with previous release.