### PR TITLE
STRM-476: Fixed api paths

### DIFF
--- a/src/main/java/com/c8db/internal/InternalC8Admin.java
+++ b/src/main/java/com/c8db/internal/InternalC8Admin.java
@@ -34,8 +34,8 @@ public abstract class InternalC8Admin<A extends InternalC8DB<E>, D extends Inter
 
     protected static final String PATH_API_TENANTS = "/_api/tenants";
     protected static final String PATH_API_TENANT = "/_api/tenant";
-    protected static final String PATH_API_FEATURES = "/features";
-    protected static final String PATH_API_LIMITS = "/limits";
+    protected static final String PATH_API_FEATURES = "/_api/features";
+    protected static final String PATH_API_LIMITS = "/_api/limits";
     protected static final String PATH_ENABLE = "enable";
     protected static final String PATH_TENANT = "tenant";
     protected static final String PATH_API_METRICS = "/_api/metrics/query";

--- a/src/main/java/com/c8db/internal/InternalC8Collection.java
+++ b/src/main/java/com/c8db/internal/InternalC8Collection.java
@@ -72,9 +72,9 @@ public abstract class InternalC8Collection<A extends InternalC8DB<E>, D extends 
 
     private static final String COLLECTION_QUERY_PARAM = "collection";
 
-    protected static final String PATH_API_COLLECTION = "/collection";
-    protected static final String PATH_API_DOCUMENT = "/document";
-    protected static final String PATH_API_INDEX = "/index";
+    protected static final String PATH_API_COLLECTION = "/_api/collection";
+    protected static final String PATH_API_DOCUMENT = "/_api/document";
+    protected static final String PATH_API_INDEX = "/_api/index";
 
     private static final String MERGE_OBJECTS = "mergeObjects";
     private static final String IGNORE_REVS = "ignoreRevs";

--- a/src/main/java/com/c8db/internal/InternalC8Database.java
+++ b/src/main/java/com/c8db/internal/InternalC8Database.java
@@ -69,25 +69,30 @@ import java.util.Map;
 public abstract class InternalC8Database<A extends InternalC8DB<E>, E extends C8Executor>
         extends C8Executeable<E> {
 
-    protected static final String PATH_API_DATABASE = "/database";
+    protected static final String PATH_API_DATABASE = "/_api/database";
     protected static final String PATH_API_DCLIST = "/datacenter";
     protected static final String PATH_API_TENANT = "/_tenant";
     protected static final String PATH_API_USER = "/_api/user";
     protected static final String PATH_API_VERSION = "/_admin/version";
     protected static final String PATH_API_STREAMS = "/_api/streams";
+    // TODO: doesnt exist in API Reference. Should it be removed?
     protected static final String PATH_API_TRANSACTION = "/transaction";
-    protected static final String PATH_API_CURSOR = "/cursor";
-    protected static final String PATH_API_QUERY = "/query";
+    protected static final String PATH_API_CURSOR = "/_api/cursor";
+    protected static final String PATH_API_QUERY = "/_api/query";
+    // TODO: doesnt exist in API Reference. Should it be removed?
     protected static final String PATH_API_QUERY_CURRENT = "/query/current";
     protected static final String PATH_API_EXPLAIN = "explain";
+    // TODO: doesnt exist in API Reference. Should it be removed?
     protected static final String PATH_API_QUERY_SLOW = "/query/slow";
+    // TODO: doesnt exist in API Reference. Should it be removed?
     protected static final String PATH_API_QUERY_PROPERTIES = "/query/properties";
-    protected static final String PATH_API_USER_QUERIES = "/restql";
+    protected static final String PATH_API_USER_QUERIES = "/_api/restql";
 
     protected static final String QUERY_PARAM_GLOBAL = "global";
     protected static final String QUERY_PARAM_FULL = "full";
-
+    // TODO: doesnt exist in API Reference. Should it be removed?
     private static final String PATH_API_BEGIN_STREAM_TRANSACTION = "/_api/transaction/begin";
+    // TODO: doesnt exist in API Reference. Should it be removed?
     private static final String PATH_API_TRAVERSAL = "/_api/traversal";
 
     private final String tenant;

--- a/src/main/java/com/c8db/internal/InternalC8Event.java
+++ b/src/main/java/com/c8db/internal/InternalC8Event.java
@@ -36,7 +36,7 @@ import com.c8db.velocystream.Response;
 public abstract class InternalC8Event<A extends InternalC8DB<E>, D extends InternalC8Database<A, E>, E extends C8Executor>
         extends C8Executeable<E> {
 
-    protected static final String PATH_API_EVENT = "/events";
+    protected static final String PATH_API_EVENT = "/_api/events";
 
     private static final String RETURN_OLD = "returnOld";
     private static final String SILENT = "silent";


### PR DESCRIPTION
The issue was that `c8db` removed an old path to Document API.
`/_fabric/{fabric}/document/{collection}/{key}` doesn't work anymore.
We should use `/_fabric/{fabric}/_api/document/{collection}/{key}`

I added `TODO` comment to paths that do not use anymore. And maybe we can delete outdated methods.