### PR TITLE
STRM-485: Add level to permissions

### DIFF
--- a/src/main/java/com/c8db/entity/Permissions.java
+++ b/src/main/java/com/c8db/entity/Permissions.java
@@ -25,15 +25,29 @@ public enum Permissions {
     /**
      * read and write access
      */
-    RW,
+    RW(0),
     /**
      * read-only access
      */
-    RO, NONE,
+    RO(1),
+
+    /*
+     * no access
+     */
+    NONE(2),
 
     /**
      * default access
      */
-    UNDEFINED
+    UNDEFINED(3);
 
+    private final int level;
+
+    private Permissions(int level) {
+        this.level = level;
+    }
+
+    public int getLevel() {
+        return level;
+    }
 }


### PR DESCRIPTION
Description: 

In permissions logic for c8cep and c8streams uses `permission.ordinal()` method for handling access to endpoints. We must not use this method because it can be changed in the future. What sies java documentation:

> Returns the ordinal of this enumeration constant (its position in its enum declaration, where the initial constant is assigned an ordinal of zero). Most programmers will have no use for this method. It is designed for use by sophisticated enum-based data structures, such as `java.util.EnumSet` and `java.util.EnumMap`. 

Solution:

Add `level` method in Permissions class

 In the next PRs will be changes `permission.ordinal()` to `permission.level()`  in permissions logic in `c8cep` and `c8streams` repositories.