### PR TITLE
CEP-458: 1.1.25.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.25.9-SNAPSHOT</version>
+    <version>1.1.25.9</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.25.1</tag>
+        <tag>c84j-1.1.25.9</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.25.9</version>
+    <version>1.1.25.10-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.25.9</tag>
+        <tag>c84j-1.1.25.1</tag>
     </scm>
 
     <organization>

--- a/src/main/java/com/c8db/C8DB.java
+++ b/src/main/java/com/c8db/C8DB.java
@@ -642,18 +642,18 @@ public interface C8DB extends C8SerializationAccessor {
             final int max = maxConnections != null ? Math.max(1, maxConnections) : protocolMaxConnections;
 
             final ConnectionFactory connectionFactory = (protocol == null || Protocol.VST == protocol)
-                    ? new VstConnectionFactorySync(host, timeout, connectionTtl, useSsl, sslContext)
+                    ? new VstConnectionFactorySync(timeout, connectionTtl, useSsl, sslContext)
                     : new HttpConnectionFactory(timeout, responseSizeLimit, user, password, email, jwtAuth, useSsl, sslContext, custom, protocol,
                             connectionTtl, httpCookieSpec, jwtToken, apiKey, hosts.get(Service.C8DB).get(0));
 
             final Map<Service, Collection<Host>> hostsMatrix = createHostMatrix(max, connectionFactory);
             final HostResolver hostResolver = createHostResolver(hostsMatrix, max, connectionFactory);
-            final HostHandler hostHandler = createHostHandler(hostResolver);
+            final Map<Service, HostHandler> hostHandlerMatrix = createHostHandlerMatrix(hostResolver);
             return new C8DBImpl(
-                    new VstCommunicationSync.Builder(hostHandler).timeout(timeout).user(user).password(password)
+                    new VstCommunicationSync.Builder(hostHandlerMatrix).timeout(timeout).user(user).password(password)
                             .useSsl(useSsl).sslContext(sslContext).chunksize(chunksize).maxConnections(maxConnections)
                             .connectionTtl(connectionTtl),
-                    new HttpCommunication.Builder(hostHandler), util, protocol, hostResolver, new C8Context());
+                    new HttpCommunication.Builder(hostHandlerMatrix), util, protocol, hostResolver, new C8Context());
         }
 
     }

--- a/src/main/java/com/c8db/internal/http/HttpConnection.java
+++ b/src/main/java/com/c8db/internal/http/HttpConnection.java
@@ -103,13 +103,14 @@ public class HttpConnection implements Connection {
     private volatile String defaultJWT;
     private final String apiKey;
     private final HostDescription auxHost;
+    private final Service service;
 
     private HttpConnection(final HostDescription host, final Integer timeout, final Integer responseSizeLimit,
                            final String user, final String password,
                            final String email, final Boolean jwtAuthEnabled, final Boolean useSsl,
                            final SSLContext sslContext, final C8Serialization util,
                            final Protocol contentType, final Long ttl, final String httpCookieSpec,
-                           final String jwt, final String apiKey, final HostDescription auxHost) {
+                           final String jwt, final String apiKey, final HostDescription auxHost, final Service service) {
 
         super();
         this.host = host;
@@ -124,6 +125,7 @@ public class HttpConnection implements Connection {
         this.defaultJWT = jwt;
         this.apiKey = apiKey;
         this.auxHost = auxHost;
+        this.service = service;
         final RegistryBuilder<ConnectionSocketFactory> registryBuilder = RegistryBuilder
                 .create();
         if (Boolean.TRUE == useSsl) {
@@ -177,7 +179,7 @@ public class HttpConnection implements Connection {
         client = builder.build();
     }
 
-    private static String buildUrl(final String baseUrl, final Request request, Service service) throws UnsupportedEncodingException {
+    private static String buildUrl(final String baseUrl, final Request request, final Service service) throws UnsupportedEncodingException {
         final StringBuilder sb = new StringBuilder().append(baseUrl);
         final String database = request.getDatabase();
         final String tenant = request.getTenant();
@@ -240,7 +242,7 @@ public class HttpConnection implements Connection {
         client.close();
     }
 
-    public Response execute(final Request request, final Service service) throws C8DBException, IOException {
+    public Response execute(final Request request) throws C8DBException, IOException {
         final String url = buildUrl(buildBaseUrl(host), request, service);
         final HttpRequestBase httpRequest = buildHttpRequestBase(request, url);
         httpRequest.setHeader("User-Agent", "Mozilla/5.0 (compatible; C8DB-JavaDriver/1.1; +http://mt.orz.at/)");
@@ -261,7 +263,7 @@ public class HttpConnection implements Connection {
                 LOGGER.debug("Using API Key for authenication.");
                 httpRequest.addHeader("Authorization", "apikey " + apiKey);
             } else if (jwt == null) { //Generate JWT using user credentials if jwt and apikey are absent
-                addJWT(request, service);
+                addJWT(request);
                 LOGGER.debug("Using JWT for authentication.");
                 httpRequest.addHeader("Authorization", "bearer " + jwt);
             } else { //Add Header when JWT is provided
@@ -283,13 +285,13 @@ public class HttpConnection implements Connection {
         } catch (C8DBException ex) {
             if (ex.getResponseCode().equals(401)) {
                 // jwt might has expired refresh it
-                addJWT(request, service);
+                addJWT(request);
                 httpRequest.removeHeaders("Authorization");
                 httpRequest.addHeader("Authorization", "bearer " + jwt);
                 response = buildResponse(client.execute(httpRequest));
                 checkError(response);
             } else if (ex.getResponseCode() >= 500) {
-                response = retryRequest(request, httpRequest, service);
+                response = retryRequest(request, httpRequest);
             } else if (ex.getResponseCode() >= 400) {
                 // Handle HTTP Error messages.
                 checkError(response);
@@ -297,12 +299,12 @@ public class HttpConnection implements Connection {
                 checkError(response);
             }
         } catch (UnknownHostException | NoHttpResponseException ex) {
-            response = retryRequest(request, httpRequest, service);
+            response = retryRequest(request, httpRequest);
         }
         return response;
     }
 
-    private Response retryRequest(final Request request, HttpRequestBase httpRequest, Service service) throws IOException {
+    private Response retryRequest(final Request request, HttpRequestBase httpRequest) throws IOException {
         Response response = null;
 
         for (int currentWaitTime = INITIAL_SLEEP_TIME_SEC; currentWaitTime <= MAX_SLEEP_TIME_SEC; currentWaitTime *= SLEEP_TIME_MULTIPLIER) {
@@ -317,7 +319,7 @@ public class HttpConnection implements Connection {
             } catch (Exception e) {
                 if (e instanceof C8DBException && ((C8DBException) e).getResponseCode().equals(401)) {
                     // jwt might has expired refresh it
-                    addJWT(request, service);
+                    addJWT(request);
                     httpRequest.removeHeaders("Authorization");
                     httpRequest.addHeader("Authorization", "bearer " + jwt);
                 }
@@ -336,7 +338,7 @@ public class HttpConnection implements Connection {
         }
     }
 
-    private synchronized void addJWT(final Request request, Service service) throws IOException {
+    private synchronized void addJWT(final Request request) throws IOException {
         addServiceJWT();
         if(StringUtils.isNotEmpty(user) && !host.getHost().equals(auxHost.getHost()) && service != Service.C8FUNCTION) {
             addUserJWT(request.getTenant(), user);
@@ -501,6 +503,7 @@ public class HttpConnection implements Connection {
         private String jwt;
         private String apiKey;
         private HostDescription auxHost;
+        private Service service;
 
         public Builder user(final String user) {
             this.user = user;
@@ -582,9 +585,14 @@ public class HttpConnection implements Connection {
             return this;
         }
 
+        public Builder service(final Service service) {
+            this.service = service;
+            return this;
+        }
+
         public HttpConnection build() {
             return new HttpConnection(host, timeout, responseSizeLimit, user, password, email, jwtAuthEnabled, useSsl, sslContext, util,
-                    contentType, ttl, httpCookieSpec, jwt, apiKey, auxHost);
+                    contentType, ttl, httpCookieSpec, jwt, apiKey, auxHost, service);
         }
     }
 

--- a/src/main/java/com/c8db/internal/http/HttpConnectionFactory.java
+++ b/src/main/java/com/c8db/internal/http/HttpConnectionFactory.java
@@ -22,6 +22,7 @@ package com.c8db.internal.http;
 import javax.net.ssl.SSLContext;
 
 import com.c8db.Protocol;
+import com.c8db.Service;
 import com.c8db.internal.net.Connection;
 import com.c8db.internal.net.ConnectionFactory;
 import com.c8db.internal.net.HostDescription;
@@ -44,8 +45,8 @@ public class HttpConnectionFactory implements ConnectionFactory {
     }
 
     @Override
-    public Connection create(final HostDescription host) {
-        return builder.host(host).build();
+    public Connection create(final HostDescription host, final Service service) {
+        return builder.host(host).service(service).build();
     }
 
 }

--- a/src/main/java/com/c8db/internal/net/ConnectionFactory.java
+++ b/src/main/java/com/c8db/internal/net/ConnectionFactory.java
@@ -16,11 +16,13 @@
 
 package com.c8db.internal.net;
 
+import com.c8db.Service;
+
 /**
  *
  */
 public interface ConnectionFactory {
 
-    Connection create(final HostDescription host);
+    Connection create(final HostDescription host, final Service service);
 
 }

--- a/src/main/java/com/c8db/internal/net/ConnectionPoolImpl.java
+++ b/src/main/java/com/c8db/internal/net/ConnectionPoolImpl.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.c8db.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,20 +39,22 @@ public class ConnectionPoolImpl implements ConnectionPool {
     private final List<Connection> connections;
     private int current;
     private final ConnectionFactory factory;
+    private final Service service;
 
     public ConnectionPoolImpl(final HostDescription host, final Integer maxConnections,
-            final ConnectionFactory factory) {
+            final ConnectionFactory factory, Service service) {
         super();
         this.host = host;
         this.maxConnections = maxConnections;
         this.factory = factory;
+        this.service = service;
         connections = new ArrayList<Connection>();
         current = 0;
     }
 
     @Override
     public Connection createConnection(final HostDescription host) {
-        return factory.create(host);
+        return factory.create(host, service);
     }
 
     @Override

--- a/src/main/java/com/c8db/internal/net/DirtyReadHostHandler.java
+++ b/src/main/java/com/c8db/internal/net/DirtyReadHostHandler.java
@@ -12,16 +12,15 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- *  Modifications copyright (c) 2022 Macrometa Corp All rights reserved.
- *
  */
 
 package com.c8db.internal.net;
 
-import com.c8db.Service;
 import java.io.IOException;
 
+/**
+ *
+ */
 public class DirtyReadHostHandler implements HostHandler {
 
     private final HostHandler master;
@@ -36,17 +35,11 @@ public class DirtyReadHostHandler implements HostHandler {
 
     private HostHandler determineHostHandler() {
         switch (currentAccessType) {
-        case DIRTY_READ:
-            return follower;
-        default:
-            return master;
+            case DIRTY_READ:
+                return follower;
+            default:
+                return master;
         }
-    }
-
-    @Override
-    public void applyService(Service service) {
-        follower.applyService(service);
-        master.applyService(service);
     }
 
     @Override

--- a/src/main/java/com/c8db/internal/net/ExtendedHostResolver.java
+++ b/src/main/java/com/c8db/internal/net/ExtendedHostResolver.java
@@ -107,13 +107,13 @@ public class ExtendedHostResolver implements HostResolver {
                     final String[] s = endpoint.replaceAll(".*://", "").split(":");
                     if (s.length == 2) {
                         final HostDescription description = new HostDescription(s[0], Integer.valueOf(s[1]));
-                        hosts.addHost(HostUtils.createHost(description, maxConnections, connectionFactory));
+                        hosts.addHost(HostUtils.createHost(description, maxConnections, connectionFactory, service));
                     } else if (s.length == 4) {
                         // IPV6 Address - TODO: we need a proper function to resolve AND support IPV4 &
                         // IPV6 functions
                         // globally
                         final HostDescription description = new HostDescription("127.0.0.1", Integer.valueOf(s[3]));
-                        hosts.addHost(HostUtils.createHost(description, maxConnections, connectionFactory));
+                        hosts.addHost(HostUtils.createHost(description, maxConnections, connectionFactory, service));
                     } else {
                         LOGGER.warn("Skip Endpoint (Missing Port)" + endpoint);
                     }

--- a/src/main/java/com/c8db/internal/net/FallbackHostHandler.java
+++ b/src/main/java/com/c8db/internal/net/FallbackHostHandler.java
@@ -12,9 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- *  Modifications copyright (c) 2022 Macrometa Corp All rights reserved.
- *
  */
 
 package com.c8db.internal.net;
@@ -25,30 +22,21 @@ import com.c8db.Service;
 import java.io.IOException;
 import java.util.List;
 
-
 public class FallbackHostHandler implements HostHandler {
 
     private Host current;
     private Host lastSuccess;
     private int iterations;
     private final HostResolver resolver;
-    private Service service;
+    private final Service service;
     private boolean firstOpened;
-    private boolean initialized;
 
-    public FallbackHostHandler(final HostResolver resolver) {
+    public FallbackHostHandler(final HostResolver resolver, final Service service) {
         this.resolver = resolver;
+        this.service = service;
         iterations = 0;
+        current = lastSuccess = resolver.resolve(service, true, false).getHostsList().get(0);
         firstOpened = true;
-    }
-
-    @Override
-    public void applyService(Service service) {
-        if (!initialized || this.service != service) {
-            this.service = service;
-            current = lastSuccess = resolver.resolve(service,true, false).getHostsList().get(0);
-            initialized = true;
-        }
     }
 
     @Override
@@ -103,3 +91,4 @@ public class FallbackHostHandler implements HostHandler {
     }
 
 }
+

--- a/src/main/java/com/c8db/internal/net/HostHandler.java
+++ b/src/main/java/com/c8db/internal/net/HostHandler.java
@@ -13,19 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Modifications copyright (c) 2022 Macrometa Corp All rights reserved.
- *
  */
 
 package com.c8db.internal.net;
 
-import com.c8db.Service;
-
 import java.io.IOException;
 
 public interface HostHandler {
-
-    void applyService(Service name);
 
     Host get(HostHandle hostHandle, AccessType accessType);
 

--- a/src/main/java/com/c8db/internal/net/RandomHostHandler.java
+++ b/src/main/java/com/c8db/internal/net/RandomHostHandler.java
@@ -25,34 +25,27 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 
+/**
+ *
+ */
 public class RandomHostHandler implements HostHandler {
 
     private final HostResolver resolver;
     private final HostHandler fallback;
+    private final Service service;
     private Host origin;
     private Host current;
-    private Service service;
-    private boolean initialized;
 
-    public RandomHostHandler(final HostResolver resolver, final HostHandler fallback) {
+    public RandomHostHandler(final HostResolver resolver, final HostHandler fallback, final Service service) {
         super();
         this.resolver = resolver;
         this.fallback = fallback;
-    }
-
-    @Override
-    public void applyService(Service service) {
-        if (!initialized || this.service != service) {
-            this.service = service;
-            origin = current = getRandomHost(true, false);
-            initialized = true;
-        }
-        fallback.applyService(service);
+        this.service = service;
+        origin = current = getRandomHost(true, false);
     }
 
     @Override
     public Host get(final HostHandle hostHandle, AccessType accessType) {
-
         if (current == null) {
             origin = current = getRandomHost(false, true);
         }
@@ -88,7 +81,7 @@ public class RandomHostHandler implements HostHandler {
 
     @Override
     public void close() throws IOException {
-        final HostSet hosts = resolver.resolve(service, false, false);
+        final HostSet hosts = resolver.resolve(service,false, false);
         hosts.close();
     }
 

--- a/src/main/java/com/c8db/internal/net/RoundRobinHostHandler.java
+++ b/src/main/java/com/c8db/internal/net/RoundRobinHostHandler.java
@@ -23,26 +23,24 @@ import com.c8db.Service;
 
 import java.io.IOException;
 
+/**
+ *
+ */
 public class RoundRobinHostHandler implements HostHandler {
 
     private final HostResolver resolver;
-
+    private final Service service;
     private int current;
     private int fails;
     private Host currentHost;
-    private Service service;
 
-    public RoundRobinHostHandler(final HostResolver resolver) {
+    public RoundRobinHostHandler(final HostResolver resolver, final Service service) {
         super();
         this.resolver = resolver;
-        resolver.resolve(Service.C8DB, true, false);
+        this.service = service;
+        resolver.resolve(service, true, false);
         current = 0;
         fails = 0;
-    }
-
-    @Override
-    public void applyService(Service service) {
-        this.service = service;
     }
 
     @Override

--- a/src/main/java/com/c8db/internal/util/HostUtils.java
+++ b/src/main/java/com/c8db/internal/util/HostUtils.java
@@ -49,8 +49,8 @@ public final class HostUtils {
     }
 
     public static Host createHost(final HostDescription description, final int maxConnections,
-            final ConnectionFactory factory) {
-        return new HostImpl(new ConnectionPoolImpl(description, maxConnections, factory), description);
+            final ConnectionFactory factory, final Service service) {
+        return new HostImpl(new ConnectionPoolImpl(description, maxConnections, factory, service), description);
     }
 
     public static Map<Service, List<Host>> cloneHostMatrix(final Map<Service, Collection<Host>> hostsMatrix) {

--- a/src/main/java/com/c8db/internal/velocystream/VstCommunicationSync.java
+++ b/src/main/java/com/c8db/internal/velocystream/VstCommunicationSync.java
@@ -18,6 +18,7 @@ package com.c8db.internal.velocystream;
 
 import javax.net.ssl.SSLContext;
 
+import com.c8db.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +32,8 @@ import com.c8db.util.C8Serialization;
 import com.c8db.velocystream.Request;
 import com.c8db.velocystream.Response;
 
+import java.util.Map;
+
 /**
  *
  */
@@ -40,7 +43,7 @@ public class VstCommunicationSync extends VstCommunication<Response, VstConnecti
 
     public static class Builder {
 
-        private final HostHandler hostHandler;
+        private final Map<Service, HostHandler> hostHandlerMatrix;
         private Integer timeout;
         private Long connectionTtl;
         private String user;
@@ -50,13 +53,13 @@ public class VstCommunicationSync extends VstCommunication<Response, VstConnecti
         private Integer chunksize;
         private Integer maxConnections;
 
-        public Builder(final HostHandler hostHandler) {
+        public Builder(final Map<Service, HostHandler> hostHandlerMatrix) {
             super();
-            this.hostHandler = hostHandler;
+            this.hostHandlerMatrix = hostHandlerMatrix;
         }
 
         public Builder(final Builder builder) {
-            this(builder.hostHandler);
+            this(builder.hostHandlerMatrix);
             timeout(builder.timeout).user(builder.user).password(builder.password).useSsl(builder.useSsl)
                     .sslContext(builder.sslContext).chunksize(builder.chunksize).maxConnections(builder.maxConnections);
         }
@@ -102,16 +105,16 @@ public class VstCommunicationSync extends VstCommunication<Response, VstConnecti
         }
 
         public VstCommunication<Response, VstConnectionSync> build(final C8Serialization util) {
-            return new VstCommunicationSync(hostHandler, timeout, user, password, useSsl, sslContext, util, chunksize,
+            return new VstCommunicationSync(hostHandlerMatrix, timeout, user, password, useSsl, sslContext, util, chunksize,
                     maxConnections, connectionTtl);
         }
 
     }
 
-    protected VstCommunicationSync(final HostHandler hostHandler, final Integer timeout, final String user,
+    protected VstCommunicationSync(final Map<Service, HostHandler> hostHandlerMatrix, final Integer timeout, final String user,
             final String password, final Boolean useSsl, final SSLContext sslContext, final C8Serialization util,
             final Integer chunksize, final Integer maxConnections, final Long ttl) {
-        super(timeout, user, password, useSsl, sslContext, util, chunksize, hostHandler);
+        super(timeout, user, password, useSsl, sslContext, util, chunksize, hostHandlerMatrix);
     }
 
     @Override

--- a/src/main/java/com/c8db/internal/velocystream/VstConnectionFactorySync.java
+++ b/src/main/java/com/c8db/internal/velocystream/VstConnectionFactorySync.java
@@ -18,6 +18,7 @@ package com.c8db.internal.velocystream;
 
 import javax.net.ssl.SSLContext;
 
+import com.c8db.Service;
 import com.c8db.internal.net.Connection;
 import com.c8db.internal.net.ConnectionFactory;
 import com.c8db.internal.net.HostDescription;
@@ -31,7 +32,7 @@ public class VstConnectionFactorySync implements ConnectionFactory {
 
     private final VstConnectionSync.Builder builder;
 
-    public VstConnectionFactorySync(final HostDescription host, final Integer timeout, final Long connectionTtl,
+    public VstConnectionFactorySync(final Integer timeout, final Long connectionTtl,
             final Boolean useSsl, final SSLContext sslContext) {
         super();
         builder = new VstConnectionSync.Builder().timeout(timeout).ttl(connectionTtl).useSsl(useSsl)
@@ -39,8 +40,8 @@ public class VstConnectionFactorySync implements ConnectionFactory {
     }
 
     @Override
-    public Connection create(final HostDescription host) {
-        return builder.messageStore(new MessageStore()).host(host).build();
+    public Connection create(final HostDescription host, final Service service) {
+        return builder.messageStore(new MessageStore()).host(host).service(service).build();
     }
 
 }

--- a/src/main/java/com/c8db/internal/velocystream/internal/VstConnection.java
+++ b/src/main/java/com/c8db/internal/velocystream/internal/VstConnection.java
@@ -36,6 +36,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
+import com.c8db.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,13 +66,14 @@ public abstract class VstConnection implements Connection {
     private InputStream inputStream;
 
     private final HostDescription host;
+    private final Service service;
 
     private HashMap<Long, Long> sendTimestamps = new HashMap<Long, Long>();
 
     private String connectionName;
 
     protected VstConnection(final HostDescription host, final Integer timeout, final Long ttl, final Boolean useSsl,
-            final SSLContext sslContext, final MessageStore messageStore) {
+            final SSLContext sslContext, final MessageStore messageStore, final Service service) {
         super();
         this.host = host;
         this.timeout = timeout;
@@ -79,6 +81,7 @@ public abstract class VstConnection implements Connection {
         this.useSsl = useSsl;
         this.sslContext = sslContext;
         this.messageStore = messageStore;
+        this.service = service;
 
         connectionName = "conenction_" + System.currentTimeMillis() + "_" + Math.random();
         LOGGER.debug("Connection " + connectionName + " created");

--- a/src/main/java/com/c8db/internal/velocystream/internal/VstConnectionSync.java
+++ b/src/main/java/com/c8db/internal/velocystream/internal/VstConnectionSync.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
 
 import com.c8db.C8DBException;
+import com.c8db.Service;
 import com.c8db.internal.net.HostDescription;
 
 /**
@@ -39,6 +40,7 @@ public class VstConnectionSync extends VstConnection {
         private Long ttl;
         private Boolean useSsl;
         private SSLContext sslContext;
+        private Service service;
 
         public Builder host(final HostDescription host) {
             this.host = host;
@@ -70,14 +72,19 @@ public class VstConnectionSync extends VstConnection {
             return this;
         }
 
+        public Builder service(final Service service) {
+            this.service = service;
+            return this;
+        }
+
         public VstConnectionSync build() {
-            return new VstConnectionSync(host, timeout, ttl, useSsl, sslContext, messageStore);
+            return new VstConnectionSync(host, timeout, ttl, useSsl, sslContext, messageStore, service);
         }
     }
 
     private VstConnectionSync(final HostDescription host, final Integer timeout, final Long ttl, final Boolean useSsl,
-            final SSLContext sslContext, final MessageStore messageStore) {
-        super(host, timeout, ttl, useSsl, sslContext, messageStore);
+            final SSLContext sslContext, final MessageStore messageStore, final Service service) {
+        super(host, timeout, ttl, useSsl, sslContext, messageStore, service);
     }
 
     public Message write(final Message message, final Collection<Chunk> chunks) throws C8DBException {

--- a/src/test/java/com/c8db/internal/HostHandlerTest.java
+++ b/src/test/java/com/c8db/internal/HostHandlerTest.java
@@ -83,8 +83,7 @@ public class HostHandlerTest {
 
     @Test
     public void fallbachHostHandlerSingleHost() {
-        final HostHandler handler = new FallbackHostHandler(SINGLE_HOST);
-        handler.applyService(Service.C8DB);
+        final HostHandler handler = new FallbackHostHandler(SINGLE_HOST, Service.C8DB);
         assertThat(handler.get(null, null), is(HOST_0));
         handler.fail();
         assertThat(handler.get(null, null), is(HOST_0));
@@ -92,8 +91,7 @@ public class HostHandlerTest {
 
     @Test
     public void fallbackHostHandlerMultipleHosts() {
-        final HostHandler handler = new FallbackHostHandler(MULTIPLE_HOSTS);
-        handler.applyService(Service.C8DB);
+        final HostHandler handler = new FallbackHostHandler(MULTIPLE_HOSTS, Service.C8DB);
         for (int i = 0; i < 3; i++) {
             assertThat(handler.get(null, null), is(HOST_0));
             handler.fail();
@@ -112,8 +110,7 @@ public class HostHandlerTest {
 
     @Test
     public void randomHostHandlerSingleHost() {
-        final HostHandler handler = new RandomHostHandler(SINGLE_HOST, new FallbackHostHandler(SINGLE_HOST));
-        handler.applyService(Service.C8DB);
+        final HostHandler handler = new RandomHostHandler(SINGLE_HOST, new FallbackHostHandler(SINGLE_HOST, Service.C8DB), Service.C8DB);
         assertThat(handler.get(null, null), is(HOST_0));
         handler.fail();
         assertThat(handler.get(null, null), is(HOST_0));
@@ -121,8 +118,7 @@ public class HostHandlerTest {
 
     @Test
     public void randomHostHandlerMultipeHosts() {
-        final HostHandler handler = new RandomHostHandler(MULTIPLE_HOSTS, new FallbackHostHandler(MULTIPLE_HOSTS));
-        handler.applyService(Service.C8DB);
+        final HostHandler handler = new RandomHostHandler(MULTIPLE_HOSTS, new FallbackHostHandler(MULTIPLE_HOSTS, Service.C8DB), Service.C8DB);
         final Host pick0 = handler.get(null, null);
         assertThat(pick0, anyOf(is(HOST_0), is(HOST_1), is(HOST_2)));
         handler.fail();
@@ -133,8 +129,7 @@ public class HostHandlerTest {
 
     @Test
     public void roundRobinHostHandlerSingleHost() {
-        final HostHandler handler = new RoundRobinHostHandler(SINGLE_HOST);
-        handler.applyService(Service.C8DB);
+        final HostHandler handler = new RoundRobinHostHandler(SINGLE_HOST, Service.C8DB);
         assertThat(handler.get(null, null), is(HOST_0));
         handler.fail();
         assertThat(handler.get(null, null), is(HOST_0));
@@ -142,8 +137,7 @@ public class HostHandlerTest {
 
     @Test
     public void roundRobinHostHandlerMultipleHosts() {
-        final HostHandler handler = new RoundRobinHostHandler(MULTIPLE_HOSTS);
-        handler.applyService(Service.C8DB);
+        final HostHandler handler = new RoundRobinHostHandler(MULTIPLE_HOSTS, Service.C8DB);
         final Host pick0 = handler.get(null, null);
         assertThat(pick0, anyOf(is(HOST_0), is(HOST_1), is(HOST_2)));
         final Host pick1 = handler.get(null, null);


### PR DESCRIPTION
The issue happens because a single instance of `HostHandler` worked with hosts for multiple services (`Service.C8DB`, `Service.C8STREAMS`, `Service.C8FUNCTION`) It caused an issue because instead of, for example, `C8DB` host it used `C8STREAMS` host. `HostHandler` was constructed to use only got single service. 
Therefore, the solution here is to set only one `service` per `HostHandler`.
What was done:
1. Roll back all changes(2 related latest commits) in all `HostHandler` children`DirtyReadHostHandler`, `FallbackHostHandler`, `RandomHostHandler`, `RoundRobinHostHandler` 
Commit #1 https://github.com/Macrometacorp/c84j/commit/137094273e18a3c5ab14660d3a78a78c627315c0 
Commit #2 https://github.com/Macrometacorp/c84j/commit/48e8ec9bffa9763e5261b2e9d823518e80be3a6f
2. Added `final Service service` to each  `DirtyReadHostHandler`, `FallbackHostHandler`, `RandomHostHandler`, `RoundRobinHostHandler` to make rule one `service` per `HostHandler`.
3. Extended `HttpCommunication` and `VstCommunication` to use a set of hostHadlers (`hostHadlerMatrix`) instead of a single hostHandler.