### PR TITLE
Corrected logitude and latitude types[0.17.12].

### DIFF
--- a/src/main/java/com/c8db/entity/DcInfoEntity.java
+++ b/src/main/java/com/c8db/entity/DcInfoEntity.java
@@ -13,15 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
+ * Modifications copyright (c) 2023 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.entity;
 
 import com.arangodb.velocypack.annotations.SerializedName;
 
-/**
- *
- */
 public class DcInfoEntity implements Entity {
 
     @SerializedName("_id")


### PR DESCRIPTION
Change the longitude and latitude fields in response of GET /datacenter/local from String to Double.
Ref. [C84J-16](https://macrometa.atlassian.net/browse/C84J-16)

[C84J-16]: https://macrometa.atlassian.net/browse/C84J-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ