### PR TITLE
CEP-542:

### DIFF
--- a/src/main/java/com/c8db/C8DBException.java
+++ b/src/main/java/com/c8db/C8DBException.java
@@ -58,6 +58,12 @@ public class C8DBException extends RuntimeException {
         this.entity = null;
         this.responseCode = null;
     }
+
+    public C8DBException(final String message, final Integer responseCode, final Throwable cause){
+        super(message,cause);
+        this.entity = null;
+        this.responseCode = responseCode;
+    }
     /**
      * @return ArangoDB error message
      */

--- a/src/main/java/com/c8db/internal/net/FallbackHostHandler.java
+++ b/src/main/java/com/c8db/internal/net/FallbackHostHandler.java
@@ -22,6 +22,8 @@ import com.c8db.Service;
 import java.io.IOException;
 import java.util.List;
 
+import static org.apache.http.HttpStatus.SC_SERVICE_UNAVAILABLE;
+
 public class FallbackHostHandler implements HostHandler {
 
     private Host current;
@@ -45,7 +47,7 @@ public class FallbackHostHandler implements HostHandler {
             return current;
         } else {
             reset();
-            throw new C8DBException("Cannot contact any host!");
+            throw new C8DBException("Cannot contact any host!", SC_SERVICE_UNAVAILABLE);
         }
     }
 

--- a/src/main/java/com/c8db/velocystream/Request.java
+++ b/src/main/java/com/c8db/velocystream/Request.java
@@ -32,6 +32,7 @@ public class Request {
     private final String tenant;
     private final String database;
     private final RequestType requestType;
+    private final boolean retryEnabled;
     private final String request;
     private final Map<String, String> queryParam;
     private final Map<String, String> headerParam;
@@ -39,14 +40,20 @@ public class Request {
     private VPackSlice body;
 
     public Request(final String tenant, final String database, final RequestType requestType, final String path) {
+        this(tenant, database, requestType, true, path);
+    }
+
+    public Request(final String tenant, final String database, final RequestType requestType, final boolean retryEnabled,
+                   final String path) {
         super();
         this.tenant = tenant;
         this.database = database;
-        this.requestType = requestType;
         this.request = path;
+        this.requestType = requestType;
         body = null;
         queryParam = new HashMap<String, String>();
         headerParam = new HashMap<String, String>();
+        this.retryEnabled = retryEnabled;
     }
 
     public int getVersion() {
@@ -96,6 +103,10 @@ public class Request {
 
     public Map<String, String> getHeaderParam() {
         return headerParam;
+    }
+
+    public boolean isRetryEnabled() {
+        return retryEnabled;
     }
 
     public Request putHeaderParam(final String key, final String value) {


### PR DESCRIPTION
1. CEP-542 has changes in CEP and c84j both
2. CEP 0.17.16 has dependency of c84j 1.1.25.6.
3. Merged changes for CEP-542  in cep 0.17.16  (which also adds changes to c8j4 1.1.25 i.e. release version 1.1.25.15)
4. c84j 1.1.25.15 is not compatible with cep 0.17.16 
5. hence merging changes for CEP-542  in c84j 1.1.25.8 i.e. release version 1.1.25.8.1
changes:
1. Add response code to C8DBException
2. Don't send null response when cannot connect to c8db after failed retries, instead throw C8DBException