### PR TITLE
STRM-662: Added getGroups methods for KV

### DIFF
--- a/src/main/java/com/c8db/C8KeyValue.java
+++ b/src/main/java/com/c8db/C8KeyValue.java
@@ -156,16 +156,4 @@ public interface C8KeyValue {
      * @throws C8DBException
      */
     long countKVPairs() throws C8DBException;
-
-    class C8KVCountPairsOptions extends MixinBase implements C8KVGroupIdMixin<C8KVReadKeysOptions> {}
-    class C8KVReadKeysOptions extends MixinBase implements C8KVPaginationMixin<C8KVReadKeysOptions>,
-            C8KVSortMixin<C8KVReadKeysOptions>, C8KVGroupIdMixin<C8KVReadKeysOptions> {}
-    class C8KVReadValuesOptions extends MixinBase implements C8KVKeysMixin<C8KVReadKeysOptions>,
-            C8KVPaginationMixin<C8KVReadKeysOptions>, C8KVGroupIdMixin<C8KVReadKeysOptions> {}
-    class C8KVTruncateOptions extends MixinBase implements C8KVGroupIdMixin<C8KVReadKeysOptions> {}
-    class C8KVCreateOptions extends MixinBase implements C8KVCreateMixin<C8KVCreateOptions> {}
-
-    enum Order {
-        asc, desc
-    }
 }

--- a/src/main/java/com/c8db/C8KeyValue.java
+++ b/src/main/java/com/c8db/C8KeyValue.java
@@ -20,19 +20,19 @@ public interface C8KeyValue {
 
     /**
      * Creates a KV with the given {@code options} for this KV's
-     * name, then returns KV name from the server.
+     * name
      *
-     * @param options Additional options, can be null*
-     * @return The KV name
+     * @param options Additional options, can be null
+     * @return The KV entity
      * @throws C8DBException
      */
     C8KVEntity create(C8KVCreateOptions options) throws C8DBException;
 
     /**
      * Creates a KV with the given {@code options} for this KV's
-     * name, then returns KV name from the server.
+     * name.
      *
-     * @return The KV name
+     * @return The KV entity
      * @throws C8DBException
      */
     C8KVEntity create() throws C8DBException;
@@ -55,7 +55,7 @@ public interface C8KeyValue {
     /**
      * Removes all pair from the KV
      *
-     * @param options The read options - group
+     * @param options Additional options, can be null
      * @throws C8DBException
      */
     void truncate(C8KVTruncateOptions options) throws C8DBException;
@@ -82,7 +82,7 @@ public interface C8KeyValue {
     DocumentDeleteEntity<Void> deleteKVPair(String key) throws C8DBException;
 
     /**
-     * Deletes multiple documents from the KV.
+     * Deletes multiple pairs from the KV.
      *
      * @param values The keys of the pairs or the KVs themselves
      * @return information about the pair
@@ -93,7 +93,7 @@ public interface C8KeyValue {
     /**
      * Retrieves the KV pair with the given {@code key} from the KV.
      *
-     * @param key     The key of the pair
+     * @param key The key of the pair
      * @return the document identified by the key
      */
     BaseKeyValue getKVPair(String key) throws C8DBException;
@@ -117,16 +117,16 @@ public interface C8KeyValue {
     /**
      * Retrieves multiple pairs with the given {@code _key} from the KV.
      *
-     * @param options The read options - offset, limit, order
+     * @param options Additional options, can be null
      * @return the documents and possible errors
      * @throws C8DBException
      */
    MultiDocumentEntity<BaseKeyValue> getKVPairs(C8KVReadValuesOptions options) throws C8DBException;
 
     /**
-     * Retrieves keys from key-value collection.
+     * Retrieves keys from KV collection.
      *
-     * @return
+     * @return list of keys
      * @throws C8DBException
      */
     Collection<String> getKVKeys() throws C8DBException;
@@ -134,8 +134,8 @@ public interface C8KeyValue {
     /**
      * Retrieves keys from key-value collection.
      *
-     * @param options
-     * @return
+     * @param options Additional options, can be null
+     * @return list of keys
      * @throws C8DBException
      */
     Collection<String> getKVKeys(C8KVReadKeysOptions options) throws C8DBException;
@@ -143,17 +143,34 @@ public interface C8KeyValue {
     /**
      * Retrieves number of key-value pairs in collection.
      *
-     * @param options ot set parameter group
-     * @return number of key-value pairs in collection.
+     * @param options Additional options, can be null
+     * @return number of KV pairs in collection.
      * @throws C8DBException
      */
     long countKVPairs(C8KVCountPairsOptions options) throws C8DBException;
 
     /**
-     * Retrieves number of key-value pairs in collection.
+     * Retrieves number of KV pairs in collection.
      *
-     * @return number of key-value pairs in collection.
+     * @return number of KV pairs in collection.
      * @throws C8DBException
      */
     long countKVPairs() throws C8DBException;
+
+    /**
+     * Retrieve group names of collection.
+     *
+     * @param options Additional options, can be null
+     * @return list of group names in collection
+     * @throws C8DBException
+     */
+    Collection<String> getGroups(C8KVReadGroupsOptions options) throws C8DBException;
+
+    /**
+     * Retrieve group names of collection.
+     *
+     * @return list of group names in collection
+     * @throws C8DBException
+     */
+    Collection<String> getGroups() throws C8DBException;
 }

--- a/src/main/java/com/c8db/entity/C8KVCollectionEntity.java
+++ b/src/main/java/com/c8db/entity/C8KVCollectionEntity.java
@@ -3,13 +3,24 @@
  */
 package com.c8db.entity;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor
-@Getter
 public class C8KVCollectionEntity implements Entity {
-	private String name;
-	private boolean expiration;
-	private boolean group;
+
+    private String name;
+    private boolean expiration;
+    private boolean group;
+
+    public C8KVCollectionEntity() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean hasExpiration() {
+        return expiration;
+    }
+
+    public boolean hasGroup() {
+        return group;
+    }
 }

--- a/src/main/java/com/c8db/entity/C8KVEntity.java
+++ b/src/main/java/com/c8db/entity/C8KVEntity.java
@@ -3,8 +3,11 @@
  */
 package com.c8db.entity;
 
-public class C8KVEntity  extends DocumentEntity {
-	public C8KVEntity() {
-		super();
-	}
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class C8KVEntity implements Entity {
+    private String name;
 }

--- a/src/main/java/com/c8db/internal/C8KeyValueImpl.java
+++ b/src/main/java/com/c8db/internal/C8KeyValueImpl.java
@@ -124,4 +124,14 @@ public class C8KeyValueImpl extends InternalC8KeyValue<C8DBImpl, C8DatabaseImpl,
     public long countKVPairs() throws C8DBException {
         return countKVPairs(null);
     }
+
+    @Override
+    public Collection<String> getGroups(C8KVReadGroupsOptions options) throws C8DBException {
+        return executor.execute(getAllGroups(), getAllGroupsResponseDeserializer());
+    }
+
+    @Override
+    public Collection<String> getGroups() throws C8DBException {
+        return getGroups(null);
+    }
 }

--- a/src/main/java/com/c8db/internal/InternalC8KeyValue.java
+++ b/src/main/java/com/c8db/internal/InternalC8KeyValue.java
@@ -25,6 +25,7 @@ public abstract class InternalC8KeyValue<A extends InternalC8DB<E>, D extends In
     protected static final String PATH_API_KV_PAIRS = "values";
     protected static final String PATH_API_KV_COUNT = "count";
     protected static final String PATH_API_KV_TRUNCATE = "truncate";
+    protected static final String PATH_API_KV_GROUPS = "groups";
 
     private static final String OFFSET = "offset";
     private static final String LIMIT = "limit";
@@ -276,6 +277,22 @@ public abstract class InternalC8KeyValue<A extends InternalC8DB<E>, D extends In
 
     protected Request dropRequest() {
         return request(db.tenant(), db.name(), RequestType.DELETE, PATH_API_KV, name);
+    }
+
+    protected Request getAllGroups() {
+        return request(db.tenant(), db.name(), RequestType.GET, PATH_API_KV, name, PATH_API_KV_GROUPS);
+    }
+
+    protected ResponseDeserializer<Collection<String>> getAllGroupsResponseDeserializer() {
+        return response -> {
+            Collection<String> coll = new ArrayList<>();
+            final VPackSlice kvs = response.getBody().get("groups");
+            for (final Iterator<VPackSlice> iterator = kvs.arrayIterator(); iterator.hasNext();) {
+                final VPackSlice next = iterator.next();
+                coll.add(next.getAsString());
+            }
+            return coll;
+        };
     }
 
 }

--- a/src/main/java/com/c8db/internal/InternalC8KeyValue.java
+++ b/src/main/java/com/c8db/internal/InternalC8KeyValue.java
@@ -19,7 +19,7 @@ import java.util.*;
 public abstract class InternalC8KeyValue<A extends InternalC8DB<E>, D extends InternalC8Database<A, E>, E extends C8Executor>
         extends C8Executeable<E> {
 
-    protected static final String PATH_API_KV = "/kv";
+    protected static final String PATH_API_KV = "/_api/kv";
     protected static final String PATH_API_KV_KEYS = "keys";
     protected static final String PATH_API_KV_PAIR = "value";
     protected static final String PATH_API_KV_PAIRS = "values";

--- a/src/main/java/com/c8db/model/C8KVCountPairsOptions.java
+++ b/src/main/java/com/c8db/model/C8KVCountPairsOptions.java
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) 2023 Macrometa Corp All rights reserved.
+ */
+package com.c8db.model;
+
+public class C8KVCountPairsOptions extends MixinBase implements GroupIdMixin<C8KVCountPairsOptions> {}

--- a/src/main/java/com/c8db/model/C8KVCreateMixin.java
+++ b/src/main/java/com/c8db/model/C8KVCreateMixin.java
@@ -109,7 +109,7 @@ public interface C8KVCreateMixin<R> {
 
     /**
      * @param expiration Enable TTL support (default: false)
-     * @return {@link C8KeyValue.C8KVCreateOptions}
+     * @return {@link C8KVCreateOptions}
      */
     default R expiration(final boolean expiration) {
         setProperty(EXPIRATION_PARAMETER, expiration);
@@ -122,7 +122,7 @@ public interface C8KVCreateMixin<R> {
 
     /**
      * @param group Enable group support (default: false)
-     * @return {@link C8KeyValue.C8KVCreateOptions}
+     * @return {@link C8KVCreateOptions}
      */
     default R group(final boolean group) {
         setProperty(GROUP_PARAMETER, group);

--- a/src/main/java/com/c8db/model/C8KVCreateOptions.java
+++ b/src/main/java/com/c8db/model/C8KVCreateOptions.java
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) 2023 Macrometa Corp All rights reserved.
+ */
+package com.c8db.model;
+
+public class C8KVCreateOptions extends MixinBase implements C8KVCreateMixin<C8KVCreateOptions> {}

--- a/src/main/java/com/c8db/model/C8KVReadGroupsOptions.java
+++ b/src/main/java/com/c8db/model/C8KVReadGroupsOptions.java
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) 2023 Macrometa Corp All rights reserved.
+ */
+package com.c8db.model;
+
+public class C8KVReadGroupsOptions extends MixinBase implements PaginationMixin<C8KVReadGroupsOptions> {}

--- a/src/main/java/com/c8db/model/C8KVReadKeysOptions.java
+++ b/src/main/java/com/c8db/model/C8KVReadKeysOptions.java
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) 2023 Macrometa Corp All rights reserved.
+ */
+package com.c8db.model;
+
+public class C8KVReadKeysOptions extends MixinBase implements PaginationMixin<C8KVReadKeysOptions>,
+        SortMixin<C8KVReadKeysOptions>, GroupIdMixin<C8KVReadKeysOptions> {}

--- a/src/main/java/com/c8db/model/C8KVReadValuesOptions.java
+++ b/src/main/java/com/c8db/model/C8KVReadValuesOptions.java
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) 2023 Macrometa Corp All rights reserved.
+ */
+package com.c8db.model;
+
+public class C8KVReadValuesOptions extends MixinBase implements C8KVKeysMixin<C8KVReadValuesOptions>,
+        PaginationMixin<C8KVReadValuesOptions>, GroupIdMixin<C8KVReadValuesOptions> {}

--- a/src/main/java/com/c8db/model/C8KVTruncateOptions.java
+++ b/src/main/java/com/c8db/model/C8KVTruncateOptions.java
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) 2023 Macrometa Corp All rights reserved.
+ */
+package com.c8db.model;
+
+public class C8KVTruncateOptions extends MixinBase implements GroupIdMixin<C8KVTruncateOptions> {}

--- a/src/main/java/com/c8db/model/GroupIdMixin.java
+++ b/src/main/java/com/c8db/model/GroupIdMixin.java
@@ -4,7 +4,7 @@
 
 package com.c8db.model;
 
-public interface C8KVGroupIdMixin<R> {
+public interface GroupIdMixin<R> {
 
     String GROUP_ID_PARAMETER = "groupID";
 

--- a/src/main/java/com/c8db/model/OptionsBuilder.java
+++ b/src/main/java/com/c8db/model/OptionsBuilder.java
@@ -54,7 +54,7 @@ public class OptionsBuilder {
         return options.name(name);
     }
 
-    public static C8KVCreateBodyOptions build(final C8KeyValue.C8KVCreateOptions options) {
+    public static C8KVCreateBodyOptions build(final C8KVCreateOptions options) {
         return new C8KVCreateBodyOptions()
                 .stream(options.hasStream())
                 .enableShards(options.isEnableShards())

--- a/src/main/java/com/c8db/model/PaginationMixin.java
+++ b/src/main/java/com/c8db/model/PaginationMixin.java
@@ -53,5 +53,4 @@ public interface PaginationMixin<R> {
         return limit;
     }
 
-
 }

--- a/src/main/java/com/c8db/model/PaginationMixin.java
+++ b/src/main/java/com/c8db/model/PaginationMixin.java
@@ -4,7 +4,7 @@
 
 package com.c8db.model;
 
-public interface C8KVPaginationMixin<R> {
+public interface PaginationMixin<R> {
 
     String OFFSET_PARAMETER = "offset";
     String LIMIT_PARAMETER = "limit";

--- a/src/main/java/com/c8db/model/SortMixin.java
+++ b/src/main/java/com/c8db/model/SortMixin.java
@@ -4,9 +4,7 @@
 
 package com.c8db.model;
 
-import com.c8db.C8KeyValue;
-
-public interface C8KVSortMixin<R> {
+public interface SortMixin<R> {
 
     String ORDER_PARAMETER = "order";
 
@@ -18,7 +16,7 @@ public interface C8KVSortMixin<R> {
      * @param order The order of returned KVs
      * @return options
      */
-    default R order(final C8KeyValue.Order order) {
+    default R order(final Order order) {
         setProperty(ORDER_PARAMETER, order);
         return (R) this;
     }
@@ -26,12 +24,16 @@ public interface C8KVSortMixin<R> {
     /**
      * @return the order of returned KVs
      */
-    default C8KeyValue.Order getOrder() {
-        C8KeyValue.Order order = getProperty(ORDER_PARAMETER);
+    default Order getOrder() {
+        Order order = getProperty(ORDER_PARAMETER);
         if (order == null) {
-            return C8KeyValue.Order.asc;
+            return Order.asc;
         }
         return order;
+    }
+
+    enum Order {
+        asc, desc
     }
 
 }


### PR DESCRIPTION
Should be added a new method that uses a new endpoint `GET API [/_fabric/{fabric}/_api/kv/{collection}/groups](https://akashj-dxb.eng.macrometa.io/api#/Key%20Value/get__fabric__fabric___api_kv__collection__groups) Get list of groups in collection`
The previous part of the GroupId feature was implemented in PR https://github.com/Macrometacorp/c84j/pull/122