### PR TITLE
C84J-17: Support Strong Consistency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.32-SNAPSHOT</version>
+    <version>1.1.32</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.25</tag>
+        <tag>c84j-1.1.32</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.32</version>
+    <version>1.1.33-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.32</tag>
+        <tag>c84j-1.1.25</tag>
     </scm>
 
     <organization>

--- a/src/main/java/com/c8db/C8KeyValue.java
+++ b/src/main/java/com/c8db/C8KeyValue.java
@@ -70,7 +70,23 @@ public interface C8KeyValue {
      * @return information about the document
      * @throws C8DBException
      */
-    MultiDocumentEntity<DocumentCreateEntity<BaseKeyValue>> insertKVPairs(Collection<BaseKeyValue> values) throws C8DBException;
+    MultiDocumentEntity<DocumentCreateEntity<BaseKeyValue>> insertKVPairs(Collection<BaseKeyValue> values)
+            throws C8DBException;
+
+    /**
+     * Set one or more key-value pairs in key-value collection.
+     * If the input is an array of objects then key-value pairs are created in batch.
+     * If the key does not exist the key-value pairs are created. Otherwise the entry for the key is updated.
+     * Specify expiration in UTC timestamp.
+     *
+     * @param values  A collection of KV pairs
+     * @param options Additional options, can be null
+     * @return information about the document
+     * @throws C8DBException
+     */
+    MultiDocumentEntity<DocumentCreateEntity<BaseKeyValue>> insertKVPairs(Collection<BaseKeyValue> values,
+                                                                          C8KVInsertValuesOptions options)
+            throws C8DBException;
 
     /**
      * Deletes a pair with the given {@code key} from the KV.
@@ -91,12 +107,42 @@ public interface C8KeyValue {
     MultiDocumentEntity<DocumentDeleteEntity<Void>> deleteKVPairs(Collection<?> values) throws C8DBException;
 
     /**
+     * Deletes multiple pairs from the KV.
+     *
+     * @param values The keys of the pairs or the KVs themselves
+     * @param options Additional options, can be null
+     * @return information about the pair
+     * @throws C8DBException
+     */
+    MultiDocumentEntity<DocumentDeleteEntity<Void>> deleteKVPairs(Collection<?> values, C8KVDeleteValuesOptions options)
+            throws C8DBException;
+
+    /**
+     * Deletes a pair with the given {@code key} from the KV.
+     *
+     * @param key The key of the pair
+     * @param options Additional options, can be null
+     * @return information about the pair
+     * @throws C8DBException
+     */
+    DocumentDeleteEntity<Void> deleteKVPair(String key, C8KVDeleteValueOptions options) throws C8DBException;
+
+    /**
      * Retrieves the KV pair with the given {@code key} from the KV.
      *
      * @param key The key of the pair
      * @return the document identified by the key
      */
     BaseKeyValue getKVPair(String key) throws C8DBException;
+
+    /**
+     * Retrieves the KV pair with the given {@code key} from the KV.
+     *
+     * @param key The key of the pair
+     * @param options Additional options, can be null
+     * @return the document identified by the key
+     */
+    BaseKeyValue getKVPair(String key, C8KVReadValueOptions options) throws C8DBException;
 
     /**
      * Retrieve all KV collections.

--- a/src/main/java/com/c8db/C8KeyValue.java
+++ b/src/main/java/com/c8db/C8KeyValue.java
@@ -98,6 +98,16 @@ public interface C8KeyValue {
     DocumentDeleteEntity<Void> deleteKVPair(String key) throws C8DBException;
 
     /**
+     * Deletes a pair with the given {@code key} from the KV.
+     *
+     * @param key The key of the pair
+     * @param options Additional options, can be null
+     * @return information about the pair
+     * @throws C8DBException
+     */
+    DocumentDeleteEntity<Void> deleteKVPair(String key, C8KVDeleteValueOptions options) throws C8DBException;
+
+    /**
      * Deletes multiple pairs from the KV.
      *
      * @param values The keys of the pairs or the KVs themselves
@@ -116,16 +126,6 @@ public interface C8KeyValue {
      */
     MultiDocumentEntity<DocumentDeleteEntity<Void>> deleteKVPairs(Collection<?> values, C8KVDeleteValuesOptions options)
             throws C8DBException;
-
-    /**
-     * Deletes a pair with the given {@code key} from the KV.
-     *
-     * @param key The key of the pair
-     * @param options Additional options, can be null
-     * @return information about the pair
-     * @throws C8DBException
-     */
-    DocumentDeleteEntity<Void> deleteKVPair(String key, C8KVDeleteValueOptions options) throws C8DBException;
 
     /**
      * Retrieves the KV pair with the given {@code key} from the KV.

--- a/src/main/java/com/c8db/entity/CollectionEntity.java
+++ b/src/main/java/com/c8db/entity/CollectionEntity.java
@@ -30,6 +30,8 @@ public class CollectionEntity implements Entity {
 	private CollectionType type;
 	private Boolean hasStream;
 	private CollectionModel collectionModel;
+	private Boolean strongConsistency;
+	private Boolean blobs;
 
 	public CollectionEntity() {
 		super();
@@ -69,6 +71,14 @@ public class CollectionEntity implements Entity {
 
 	public CollectionModel getCollectionModel() {
 		return collectionModel;
+	}
+
+	public Boolean getStrongConsistency() {
+		return strongConsistency;
+	}
+
+	public Boolean getBlobs() {
+		return blobs;
 	}
 
 }

--- a/src/main/java/com/c8db/entity/CollectionType.java
+++ b/src/main/java/com/c8db/entity/CollectionType.java
@@ -20,7 +20,7 @@ package com.c8db.entity;
 
 public enum CollectionType {
 
-    KV(1), DOCUMENT(2), EDGES(3), DYNAMO(4);
+    DOCUMENT(2), EDGES(3);
 
     private final int type;
 

--- a/src/main/java/com/c8db/internal/C8KeyValueImpl.java
+++ b/src/main/java/com/c8db/internal/C8KeyValueImpl.java
@@ -56,25 +56,47 @@ public class C8KeyValueImpl extends InternalC8KeyValue<C8DBImpl, C8DatabaseImpl,
     @Override
     public  MultiDocumentEntity<DocumentCreateEntity<BaseKeyValue>> insertKVPairs(final Collection<BaseKeyValue>  values)
             throws C8DBException {
-        return executor.execute(insertKVPairsRequest(values), insertKVPairsResponseDeserializer());
+        return insertKVPairs(values, null);
+    }
+
+    @Override
+    public  MultiDocumentEntity<DocumentCreateEntity<BaseKeyValue>> insertKVPairs(final Collection<BaseKeyValue>  values,
+                                                                                  C8KVInsertValuesOptions options)
+            throws C8DBException {
+        return executor.execute(insertKVPairsRequest(values, options), insertKVPairsResponseDeserializer());
     }
 
     @Override
     public DocumentDeleteEntity<Void> deleteKVPair(String key) throws C8DBException {
-        return executor.execute(deleteKVPairRequest(key),
+        return deleteKVPair(key, null);
+    }
+
+    @Override
+    public DocumentDeleteEntity<Void> deleteKVPair(String key, C8KVDeleteValueOptions options) throws C8DBException {
+        return executor.execute(deleteKVPairRequest(key, options),
                 deleteKVPairResponseDeserializer(Void.class));
     }
 
     @Override
     public MultiDocumentEntity<DocumentDeleteEntity<Void>> deleteKVPairs(Collection<?> values) throws C8DBException {
-        return executor.execute(deleteKVPairsRequest(values), deleteKVPairsResponseDeserializer(Void.class));
+        return deleteKVPairs(values, null);
+    }
+
+    @Override
+    public MultiDocumentEntity<DocumentDeleteEntity<Void>> deleteKVPairs(Collection<?> values, C8KVDeleteValuesOptions options) throws C8DBException {
+        return executor.execute(deleteKVPairsRequest(values, options), deleteKVPairsResponseDeserializer(Void.class));
     }
 
     @Override
     public BaseKeyValue getKVPair(String key) throws C8DBException {
+        return getKVPair(key, null);
+    }
+
+    @Override
+    public BaseKeyValue getKVPair(String key, C8KVReadValueOptions options) throws C8DBException {
         DocumentUtil.validateDocumentKey(key);
         try {
-            return executor.execute(getKVPairRequest(key), BaseKeyValue.class);
+            return executor.execute(getKVPairRequest(key, options), BaseKeyValue.class);
         } catch (final C8DBException e) {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug(e.getMessage(), e);

--- a/src/main/java/com/c8db/internal/InternalC8Collection.java
+++ b/src/main/java/com/c8db/internal/InternalC8Collection.java
@@ -84,7 +84,7 @@ public abstract class InternalC8Collection<A extends InternalC8DB<E>, D extends 
     private static final String OVERWRITE = "overwrite";
     private static final String OLD = "old";
     private static final String SILENT = "silent";
-
+    private static final String STRONG_CONSISTENCY = "strongConsistency";
     public static final String TRANSACTION_ID = "x-gdn-trxid";
 
     private final D db;
@@ -112,6 +112,7 @@ public abstract class InternalC8Collection<A extends InternalC8DB<E>, D extends 
         request.putQueryParam(RETURN_OLD, params.getReturnOld());
         request.putQueryParam(SILENT, params.getSilent());
         request.putQueryParam(OVERWRITE, params.getOverwrite());
+        request.putQueryParam(STRONG_CONSISTENCY, params.hasStrongConsistency());
         request.putHeaderParam(TRANSACTION_ID, params.getStreamTransactionId());
         request.setBody(util(Serializer.CUSTOM).serialize(value));
         return request;
@@ -210,6 +211,7 @@ public abstract class InternalC8Collection<A extends InternalC8DB<E>, D extends 
         final Request request = request(db.tenant(), db.name(), RequestType.GET, PATH_API_DOCUMENT,
                 DocumentUtil.createDocumentHandle(name, key));
         final DocumentReadOptions params = (options != null ? options : new DocumentReadOptions());
+        request.putQueryParam(STRONG_CONSISTENCY, params.hasStrongConsistency());
         request.putHeaderParam(C8RequestParam.IF_NONE_MATCH, params.getIfNoneMatch());
         request.putHeaderParam(C8RequestParam.IF_MATCH, params.getIfMatch());
         request.putHeaderParam(TRANSACTION_ID, params.getStreamTransactionId());
@@ -220,6 +222,7 @@ public abstract class InternalC8Collection<A extends InternalC8DB<E>, D extends 
         final DocumentReadOptions params = (options != null ? options : new DocumentReadOptions());
         final Request request = request(db.tenant(), db.name(), RequestType.PUT, PATH_API_DOCUMENT, name)
                 .putQueryParam("onlyget", true)
+                .putQueryParam(STRONG_CONSISTENCY, params.hasStrongConsistency())
                 .putHeaderParam(C8RequestParam.IF_NONE_MATCH, params.getIfNoneMatch())
                 .putHeaderParam(C8RequestParam.IF_MATCH, params.getIfMatch()).setBody(util().serialize(keys))
                 .putHeaderParam(TRANSACTION_ID, params.getStreamTransactionId());
@@ -269,6 +272,7 @@ public abstract class InternalC8Collection<A extends InternalC8DB<E>, D extends 
         request.putQueryParam(RETURN_NEW, params.getReturnNew());
         request.putQueryParam(RETURN_OLD, params.getReturnOld());
         request.putQueryParam(SILENT, params.getSilent());
+        request.putQueryParam(STRONG_CONSISTENCY, params.hasStrongConsistency());
         request.setBody(util(Serializer.CUSTOM).serialize(value));
         return request;
     }
@@ -308,6 +312,7 @@ public abstract class InternalC8Collection<A extends InternalC8DB<E>, D extends 
         request.putQueryParam(RETURN_NEW, params.getReturnNew());
         request.putQueryParam(RETURN_OLD, params.getReturnOld());
         request.putQueryParam(SILENT, params.getSilent());
+        request.putQueryParam(STRONG_CONSISTENCY, params.hasStrongConsistency());
         request.setBody(util(Serializer.CUSTOM).serialize(values,
                 new C8Serializer.Options().serializeNullValues(false).stringAsJson(true)));
         return request;
@@ -374,6 +379,7 @@ public abstract class InternalC8Collection<A extends InternalC8DB<E>, D extends 
         request.putQueryParam(RETURN_NEW, params.getReturnNew());
         request.putQueryParam(RETURN_OLD, params.getReturnOld());
         request.putQueryParam(SILENT, params.getSilent());
+        request.putQueryParam(STRONG_CONSISTENCY, params.hasStrongConsistency());
         request.setBody(util(Serializer.CUSTOM).serialize(value, new C8Serializer.Options()
                 .serializeNullValues(params.getSerializeNull() == null || params.getSerializeNull())));
         return request;
@@ -417,6 +423,7 @@ public abstract class InternalC8Collection<A extends InternalC8DB<E>, D extends 
         request.putQueryParam(RETURN_NEW, params.getReturnNew());
         request.putQueryParam(RETURN_OLD, params.getReturnOld());
         request.putQueryParam(SILENT, params.getSilent());
+        request.putQueryParam(STRONG_CONSISTENCY, params.hasStrongConsistency());
         request.setBody(util(Serializer.CUSTOM).serialize(values,
                 new C8Serializer.Options()
                         .serializeNullValues(params.getSerializeNull() == null || params.getSerializeNull())
@@ -481,6 +488,7 @@ public abstract class InternalC8Collection<A extends InternalC8DB<E>, D extends 
         request.putQueryParam(C8RequestParam.WAIT_FOR_SYNC, params.getWaitForSync());
         request.putQueryParam(RETURN_OLD, params.getReturnOld());
         request.putQueryParam(SILENT, params.getSilent());
+        request.putQueryParam(STRONG_CONSISTENCY, params.hasStrongConsistency());
         return request;
     }
 
@@ -508,6 +516,7 @@ public abstract class InternalC8Collection<A extends InternalC8DB<E>, D extends 
         request.putQueryParam(C8RequestParam.WAIT_FOR_SYNC, params.getWaitForSync());
         request.putQueryParam(RETURN_OLD, params.getReturnOld());
         request.putQueryParam(SILENT, params.getSilent());
+        request.putQueryParam(STRONG_CONSISTENCY, params.hasStrongConsistency());
         request.setBody(util().serialize(keys));
         return request;
     }
@@ -554,6 +563,7 @@ public abstract class InternalC8Collection<A extends InternalC8DB<E>, D extends 
         final Request request = request(db.tenant(), db.name(), RequestType.HEAD, PATH_API_DOCUMENT,
                 DocumentUtil.createDocumentHandle(name, key));
         final DocumentExistsOptions params = (options != null ? options : new DocumentExistsOptions());
+        request.putQueryParam(STRONG_CONSISTENCY, params.hasStrongConsistency());
         request.putHeaderParam(TRANSACTION_ID, params.getStreamTransactionId());
         request.putHeaderParam(C8RequestParam.IF_MATCH, params.getIfMatch());
         request.putHeaderParam(C8RequestParam.IF_NONE_MATCH, params.getIfNoneMatch());

--- a/src/main/java/com/c8db/internal/InternalC8Database.java
+++ b/src/main/java/com/c8db/internal/InternalC8Database.java
@@ -151,10 +151,8 @@ public abstract class InternalC8Database<A extends InternalC8DB<E>, E extends C8
     }
 
     protected Request createCollectionRequest(final String name, final CollectionCreateOptions options) {
-
         VPackSlice body = util()
                 .serialize(OptionsBuilder.build(options != null ? options : new CollectionCreateOptions(), name));
-
         return request(tenant(), name(), RequestType.POST, InternalC8Collection.PATH_API_COLLECTION).setBody(body);
     }
 

--- a/src/main/java/com/c8db/internal/InternalC8KeyValue.java
+++ b/src/main/java/com/c8db/internal/InternalC8KeyValue.java
@@ -33,6 +33,8 @@ public abstract class InternalC8KeyValue<A extends InternalC8DB<E>, D extends In
     private static final String EXPIRATION = "expiration";
     private static final String GROUP_ID = "groupID";
     private static final String GROUP = "group";
+    private static final String STRONG_CONSISTENCY = "strongConsistency";
+
 
     private static final String NEW = "new";
     private static final String OLD = "old";
@@ -54,8 +56,9 @@ public abstract class InternalC8KeyValue<A extends InternalC8DB<E>, D extends In
         return name;
     }
 
-    protected  <T> Request insertKVPairsRequest(final Collection<T> values) {
+    protected  <T> Request insertKVPairsRequest(final Collection<T> values, C8KVInsertValuesOptions options) {
         final Request request = request(db.tenant(), db.name(), RequestType.PUT, PATH_API_KV, name, PATH_API_KV_PAIR);
+        request.putQueryParam(STRONG_CONSISTENCY, options != null && options.hasStrongConsistency());
         request.setBody(util(Serializer.CUSTOM).serialize(values,
                 new C8Serializer.Options().serializeNullValues(false).stringAsJson(true)));
         return request;
@@ -98,9 +101,10 @@ public abstract class InternalC8KeyValue<A extends InternalC8DB<E>, D extends In
         };
     }
 
-    protected Request getKVPairRequest(final String key) {
+    protected Request getKVPairRequest(final String key, C8KVReadValueOptions options) {
         final Request request = request(db.tenant(), db.name(), RequestType.GET, PATH_API_KV, name, PATH_API_KV_PAIR,
                 key);
+        request.putQueryParam(STRONG_CONSISTENCY, options != null && options.hasStrongConsistency());
         return request;
     }
 
@@ -123,7 +127,7 @@ public abstract class InternalC8KeyValue<A extends InternalC8DB<E>, D extends In
 
     protected Request countKVPairsRequest(C8KVCountPairsOptions options) {
         final Request request =  request(db.tenant(), db.name(), RequestType.GET, PATH_API_KV, name, PATH_API_KV_COUNT);
-        if (options != null && StringUtils.isNotEmpty(options.getGroup())) {
+        if (options != null && StringUtils.isNotEmpty(options.getGroup())){
             request.putQueryParam(GROUP_ID, options.getGroup());
         }
         return request;
@@ -144,6 +148,7 @@ public abstract class InternalC8KeyValue<A extends InternalC8DB<E>, D extends In
         if (StringUtils.isNotEmpty(params.getGroup())) {
             request.putQueryParam(GROUP_ID, params.getGroup());
         }
+        request.putQueryParam(STRONG_CONSISTENCY, options != null && options.hasStrongConsistency());
         return request;
     }
 
@@ -197,9 +202,10 @@ public abstract class InternalC8KeyValue<A extends InternalC8DB<E>, D extends In
         };
     }
 
-    protected Request deleteKVPairRequest(final String key) {
+    protected Request deleteKVPairRequest(final String key, C8KVDeleteValueOptions options) {
         final Request request = request(db.tenant(), db.name(), RequestType.DELETE, PATH_API_KV, name, PATH_API_KV_PAIR,
                 key);
+        request.putQueryParam(STRONG_CONSISTENCY, options != null && options.hasStrongConsistency());
         return request;
     }
 
@@ -216,8 +222,9 @@ public abstract class InternalC8KeyValue<A extends InternalC8DB<E>, D extends In
         };
     }
 
-    protected <T> Request deleteKVPairsRequest(final Collection<T> keys) {
+    protected <T> Request deleteKVPairsRequest(final Collection<T> keys, C8KVDeleteValuesOptions options) {
         final Request request = request(db.tenant(), db.name(), RequestType.DELETE, PATH_API_KV, name, PATH_API_KV_PAIRS);
+        request.putQueryParam(STRONG_CONSISTENCY, options != null && options.hasStrongConsistency());
         request.setBody(util().serialize(keys));
         return request;
     }
@@ -268,10 +275,10 @@ public abstract class InternalC8KeyValue<A extends InternalC8DB<E>, D extends In
 
     protected Request truncateRequest(C8KVTruncateOptions options) {
         final Request request = request(db.tenant(), db.name(), RequestType.PUT, PATH_API_KV, name, PATH_API_KV_TRUNCATE);
-
         if (options != null && StringUtils.isNotEmpty(options.getGroup())) {
             request.putQueryParam(GROUP_ID, options.getGroup());
         }
+        request.putQueryParam(STRONG_CONSISTENCY, options != null && options.hasStrongConsistency());
         return request;
     }
 

--- a/src/main/java/com/c8db/model/C8KVCreateBodyOptions.java
+++ b/src/main/java/com/c8db/model/C8KVCreateBodyOptions.java
@@ -14,6 +14,7 @@ public class C8KVCreateBodyOptions {
     private Boolean waitForSync;
     private Boolean blobs;
     private String[] shardKeys;
+    private Boolean strongConsistency;
 
     public C8KVCreateBodyOptions() {
         super();
@@ -99,6 +100,25 @@ public class C8KVCreateBodyOptions {
      */
     public C8KVCreateBodyOptions waitForSync(final Boolean waitForSync) {
         this.waitForSync = waitForSync;
+        return this;
+    }
+
+    /**
+     * Checks whether the strongConsistency is enabled.
+     *
+     * @return true of false
+     */
+    public Boolean isStrongConsistency() {
+        return strongConsistency;
+    }
+
+    /**
+     * Sets strongConsistency collection creation property.
+     *
+     * @return {@link C8KVCreateBodyOptions}
+     */
+    public C8KVCreateBodyOptions strongConsistency(final Boolean strongConsistency) {
+        this.strongConsistency = strongConsistency;
         return this;
     }
 

--- a/src/main/java/com/c8db/model/C8KVCreateOptions.java
+++ b/src/main/java/com/c8db/model/C8KVCreateOptions.java
@@ -3,4 +3,5 @@
  */
 package com.c8db.model;
 
-public class C8KVCreateOptions extends MixinBase implements C8KVCreateMixin<C8KVCreateOptions> {}
+public class C8KVCreateOptions extends MixinBase implements C8KVCreateMixin<C8KVCreateOptions>,
+        StrongConsistencyMixin<C8KVCreateOptions> {}

--- a/src/main/java/com/c8db/model/C8KVDeleteValueOptions.java
+++ b/src/main/java/com/c8db/model/C8KVDeleteValueOptions.java
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) 2023 Macrometa Corp All rights reserved.
+ */
+package com.c8db.model;
+
+public class C8KVDeleteValueOptions extends MixinBase implements StrongConsistencyMixin<C8KVDeleteValueOptions> {}

--- a/src/main/java/com/c8db/model/C8KVDeleteValuesOptions.java
+++ b/src/main/java/com/c8db/model/C8KVDeleteValuesOptions.java
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) 2023 Macrometa Corp All rights reserved.
+ */
+package com.c8db.model;
+
+public class C8KVDeleteValuesOptions extends MixinBase implements StrongConsistencyMixin<C8KVDeleteValuesOptions> {}

--- a/src/main/java/com/c8db/model/C8KVInsertValuesOptions.java
+++ b/src/main/java/com/c8db/model/C8KVInsertValuesOptions.java
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) 2023 Macrometa Corp All rights reserved.
+ */
+package com.c8db.model;
+
+public class C8KVInsertValuesOptions extends MixinBase implements StrongConsistencyMixin<C8KVInsertValuesOptions> {}

--- a/src/main/java/com/c8db/model/C8KVReadValueOptions.java
+++ b/src/main/java/com/c8db/model/C8KVReadValueOptions.java
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) 2023 Macrometa Corp All rights reserved.
+ */
+package com.c8db.model;
+
+public class C8KVReadValueOptions extends MixinBase implements StrongConsistencyMixin<C8KVReadValueOptions> {}

--- a/src/main/java/com/c8db/model/C8KVReadValuesOptions.java
+++ b/src/main/java/com/c8db/model/C8KVReadValuesOptions.java
@@ -4,4 +4,5 @@
 package com.c8db.model;
 
 public class C8KVReadValuesOptions extends MixinBase implements C8KVKeysMixin<C8KVReadValuesOptions>,
-        PaginationMixin<C8KVReadValuesOptions>, GroupIdMixin<C8KVReadValuesOptions> {}
+        PaginationMixin<C8KVReadValuesOptions>, GroupIdMixin<C8KVReadValuesOptions>,
+        StrongConsistencyMixin<C8KVReadValuesOptions> {}

--- a/src/main/java/com/c8db/model/C8KVTruncateOptions.java
+++ b/src/main/java/com/c8db/model/C8KVTruncateOptions.java
@@ -3,4 +3,5 @@
  */
 package com.c8db.model;
 
-public class C8KVTruncateOptions extends MixinBase implements GroupIdMixin<C8KVTruncateOptions> {}
+public class C8KVTruncateOptions extends MixinBase implements GroupIdMixin<C8KVTruncateOptions>,
+        StrongConsistencyMixin<C8KVTruncateOptions> {}

--- a/src/main/java/com/c8db/model/CollectionCreateBodyOptions.java
+++ b/src/main/java/com/c8db/model/CollectionCreateBodyOptions.java
@@ -1,0 +1,101 @@
+/*
+ * DISCLAIMER
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Modifications copyright (c) 2023 Macrometa Corp All rights reserved.
+ */
+
+package com.c8db.model;
+
+import com.c8db.entity.CollectionType;
+import com.c8db.entity.KeyOptions;
+import com.c8db.entity.KeyType;
+
+public class CollectionCreateBodyOptions {
+
+    private String name;
+    private KeyOptions keyOptions;
+    private Boolean isSpot;
+    private String[] shardKeys;
+    private CollectionType type;
+    private Boolean isLocal;
+    private Boolean isSystem;
+    private Boolean stream;
+    private Boolean enableShards;
+    private Boolean waitForSync;
+    private Boolean strongConsistency;
+    private Boolean cacheEnabled;
+
+    public CollectionCreateBodyOptions() {}
+
+    protected CollectionCreateBodyOptions name(final String name) {
+        this.name = name;
+        return this;
+    }
+
+    public CollectionCreateBodyOptions keyOptions(final KeyOptions keyOptions) {
+        this.keyOptions = keyOptions;
+        return this;
+    }
+
+    public CollectionCreateBodyOptions shardKeys(final String... shardKeys) {
+        this.shardKeys = shardKeys;
+        return this;
+    }
+
+    public CollectionCreateBodyOptions type(final CollectionType type) {
+        this.type = type;
+        return this;
+    }
+
+    public CollectionCreateBodyOptions isSpot(final Boolean isSpot) {
+        this.isSpot = isSpot;
+        return this;
+    }
+
+    public CollectionCreateBodyOptions isLocal(final Boolean isLocal) {
+        this.isLocal = isLocal;
+        return this;
+    }
+
+    public CollectionCreateBodyOptions stream(final Boolean stream) {
+        this.stream = stream;
+        return this;
+    }
+
+    public CollectionCreateBodyOptions isSystem(final Boolean isSystem) {
+        this.isSystem = isSystem;
+        return this;
+    }
+
+    public CollectionCreateBodyOptions enableShards(final Boolean enableShards) {
+        this.enableShards = enableShards;
+        return this;
+    }
+
+    public CollectionCreateBodyOptions waitForSync(final Boolean waitForSync) {
+        this.waitForSync = waitForSync;
+        return this;
+    }
+
+    public CollectionCreateBodyOptions strongConsistency(final Boolean strongConsistency) {
+        this.strongConsistency = strongConsistency;
+        return this;
+    }
+
+    public CollectionCreateBodyOptions cacheEnabled(final Boolean cacheEnabled) {
+        this.cacheEnabled = cacheEnabled;
+        return this;
+    }
+}

--- a/src/main/java/com/c8db/model/CollectionCreateOptions.java
+++ b/src/main/java/com/c8db/model/CollectionCreateOptions.java
@@ -22,9 +22,8 @@ import com.c8db.entity.CollectionType;
 import com.c8db.entity.KeyOptions;
 import com.c8db.entity.KeyType;
 
-public class CollectionCreateOptions {
+public class CollectionCreateOptions extends MixinBase implements StrongConsistencyMixin<CollectionCreateOptions> {
 
-    private String name;
     private KeyOptions keyOptions;
     private Boolean isSpot;
     private String[] shardKeys;
@@ -35,22 +34,10 @@ public class CollectionCreateOptions {
     private Boolean enableShards;
     // Macrometa Corp Modification: Expose `waitForSync` property.
     private Boolean waitForSync;
+    private Boolean cacheEnabled;
 
     public CollectionCreateOptions() {
         super();
-    }
-
-    protected String getName() {
-        return name;
-    }
-
-    /**
-     * @param name The name of the collection
-     * @return options
-     */
-    protected CollectionCreateOptions name(final String name) {
-        this.name = name;
-        return this;
     }
 
     public KeyOptions getKeyOptions() {
@@ -203,6 +190,25 @@ public class CollectionCreateOptions {
      */
     public CollectionCreateOptions waitForSync(final Boolean waitForSync) {
         this.waitForSync = waitForSync;
+        return this;
+    }
+
+    /**
+     * Checks whether the cacheEnabled is enabled.
+     *
+     * @return true of false
+     */
+    public Boolean isCacheEnabled() {
+        return cacheEnabled;
+    }
+
+    /**
+     * Sets cacheEnabled collection creation property.
+     *
+     * @return {@link CollectionCreateOptions}
+     */
+    public CollectionCreateOptions cacheEnabled(final Boolean cacheEnabled) {
+        this.cacheEnabled = cacheEnabled;
         return this;
     }
 

--- a/src/main/java/com/c8db/model/DocumentCreateOptions.java
+++ b/src/main/java/com/c8db/model/DocumentCreateOptions.java
@@ -18,7 +18,7 @@ package com.c8db.model;
 
 /**
  */
-public class DocumentCreateOptions {
+public class DocumentCreateOptions extends MixinBase implements StrongConsistencyMixin<DocumentCreateOptions> {
 
     private Boolean waitForSync;
     private Boolean returnNew;

--- a/src/main/java/com/c8db/model/DocumentDeleteOptions.java
+++ b/src/main/java/com/c8db/model/DocumentDeleteOptions.java
@@ -18,7 +18,7 @@ package com.c8db.model;
 
 /**
  */
-public class DocumentDeleteOptions {
+public class DocumentDeleteOptions extends MixinBase implements StrongConsistencyMixin<DocumentDeleteOptions> {
 
     private Boolean waitForSync;
     private String ifMatch;

--- a/src/main/java/com/c8db/model/DocumentExistsOptions.java
+++ b/src/main/java/com/c8db/model/DocumentExistsOptions.java
@@ -18,7 +18,7 @@ package com.c8db.model;
 
 /**
  */
-public class DocumentExistsOptions {
+public class DocumentExistsOptions extends MixinBase implements StrongConsistencyMixin<DocumentExistsOptions> {
 
     private String ifNoneMatch;
     private String ifMatch;

--- a/src/main/java/com/c8db/model/DocumentReadOptions.java
+++ b/src/main/java/com/c8db/model/DocumentReadOptions.java
@@ -19,7 +19,7 @@ package com.c8db.model;
 /**
  *
  */
-public class DocumentReadOptions {
+public class DocumentReadOptions extends MixinBase implements StrongConsistencyMixin<DocumentReadOptions> {
 
     private String ifNoneMatch;
     private String ifMatch;

--- a/src/main/java/com/c8db/model/DocumentReplaceOptions.java
+++ b/src/main/java/com/c8db/model/DocumentReplaceOptions.java
@@ -19,7 +19,7 @@ package com.c8db.model;
 /**
  *
  */
-public class DocumentReplaceOptions {
+public class DocumentReplaceOptions extends MixinBase implements StrongConsistencyMixin<DocumentReplaceOptions>  {
 
     private Boolean waitForSync;
     private Boolean ignoreRevs;

--- a/src/main/java/com/c8db/model/DocumentUpdateOptions.java
+++ b/src/main/java/com/c8db/model/DocumentUpdateOptions.java
@@ -19,7 +19,7 @@ package com.c8db.model;
 /**
  * 
  */
-public class DocumentUpdateOptions {
+public class DocumentUpdateOptions extends MixinBase implements StrongConsistencyMixin<DocumentUpdateOptions> {
 
     private Boolean keepNull;
     private Boolean mergeObjects;

--- a/src/main/java/com/c8db/model/OptionsBuilder.java
+++ b/src/main/java/com/c8db/model/OptionsBuilder.java
@@ -60,7 +60,8 @@ public class OptionsBuilder {
                 .enableShards(options.isEnableShards())
                 .waitForSync(options.isWaitForSync())
                 .blobs(options.isBlobs())
-                .shardKeys(options.getShardKeys());
+                .shardKeys(options.getShardKeys())
+                .strongConsistency(options.hasStrongConsistency());
     }
 
     public static C8qlQueryOptions build(final C8qlQueryOptions options, final String query, final VPackSlice bindVars) {

--- a/src/main/java/com/c8db/model/OptionsBuilder.java
+++ b/src/main/java/com/c8db/model/OptionsBuilder.java
@@ -50,8 +50,20 @@ public class OptionsBuilder {
         return options.fields(fields);
     }
 
-    public static CollectionCreateOptions build(final CollectionCreateOptions options, final String name) {
-        return options.name(name);
+    public static CollectionCreateBodyOptions build(final CollectionCreateOptions options, final String name) {
+        return new CollectionCreateBodyOptions()
+                .name(name)
+                .keyOptions(options.getKeyOptions())
+                .isSpot(options.getIsSpot())
+                .shardKeys(options.getShardKeys())
+                .type(options.getType())
+                .isLocal(options.getLocal())
+                .isSystem(options.isSystem())
+                .stream(options.hasStream())
+                .enableShards(options.isEnableShards())
+                .waitForSync(options.isWaitForSync())
+                .strongConsistency(options.hasStrongConsistency())
+                .cacheEnabled(options.isCacheEnabled());
     }
 
     public static C8KVCreateBodyOptions build(final C8KVCreateOptions options) {

--- a/src/main/java/com/c8db/model/StrongConsistencyMixin.java
+++ b/src/main/java/com/c8db/model/StrongConsistencyMixin.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Macrometa Corp All rights reserved.
+ */
+
+package com.c8db.model;
+
+public interface StrongConsistencyMixin<R> {
+
+    String STRONG_CONSISTENCY = "strongConsistency";
+
+    <T> T getProperty(String name);
+
+    <T> void setProperty(String name, T value);
+
+    /**
+     * @return if a collection is strongly consistent
+     */
+    default boolean hasStrongConsistency() {
+        return getProperty(STRONG_CONSISTENCY) == Boolean.TRUE;
+    }
+
+    /**
+     * @param strongConsistency Enable strong consistency (default: false)
+     * @return options
+     */
+    default R strongConsistency(final boolean strongConsistency) {
+        setProperty(STRONG_CONSISTENCY, strongConsistency);
+        return (R) this;
+    }
+
+}


### PR DESCRIPTION
Updated the next endpoints in Key Value API: 
- POST `/_fabric/{fabric}/_api/kv/{collection}` Create key-value collection, - added strongConsistency body parameter
- DELETE  `/_fabric/{fabric}/_api/kv/{collection}/value/{key}` Remove key-value pair - added `strongConsistency` query parameter
- DELETE  `/_fabric/{fabric}/_api/kv/{collection}/values` Remove key-value pairs. - added `strongConsistency` query parameter
- GET  `/_fabric/{fabric}/_api/kv/{collection}/value/{key}`  - added `strongConsistency` query parameter
- POST `/_fabric/{fabric}/_api/kv/{collection}/values`  - added `strongConsistency` query parameter
- PUT `/_fabric/{fabric}/_api/kv/{collection}/value`  Set one or more key-value pairs - added `strongConsistency` query parameter
- PUT  `_fabric/{fabric}/_api/kv/{collection}/truncate` Remove all key-value pairs in a collection. - added `strongConsistency` query parameter