### PR TITLE
C84J-17: Add strong consistency to countKVPairs, getKVKeys methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.33</version>
+    <version>1.1.34-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.33</tag>
+        <tag>c84j-1.1.25</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.33-SNAPSHOT</version>
+    <version>1.1.33</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.25</tag>
+        <tag>c84j-1.1.33</tag>
     </scm>
 
     <organization>

--- a/src/main/java/com/c8db/internal/InternalC8KeyValue.java
+++ b/src/main/java/com/c8db/internal/InternalC8KeyValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Macrometa Corp All rights reserved.
+ * Copyright (c) 2023 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal;
@@ -127,9 +127,11 @@ public abstract class InternalC8KeyValue<A extends InternalC8DB<E>, D extends In
 
     protected Request countKVPairsRequest(C8KVCountPairsOptions options) {
         final Request request =  request(db.tenant(), db.name(), RequestType.GET, PATH_API_KV, name, PATH_API_KV_COUNT);
-        if (options != null && StringUtils.isNotEmpty(options.getGroup())){
-            request.putQueryParam(GROUP_ID, options.getGroup());
+        final C8KVCountPairsOptions params = (options != null ? options : new C8KVCountPairsOptions());
+        if (StringUtils.isNotEmpty(params.getGroup())){
+            request.putQueryParam(GROUP_ID, params.getGroup());
         }
+        request.putQueryParam(STRONG_CONSISTENCY, params.hasStrongConsistency());
         return request;
     }
 
@@ -148,7 +150,7 @@ public abstract class InternalC8KeyValue<A extends InternalC8DB<E>, D extends In
         if (StringUtils.isNotEmpty(params.getGroup())) {
             request.putQueryParam(GROUP_ID, params.getGroup());
         }
-        request.putQueryParam(STRONG_CONSISTENCY, options != null && options.hasStrongConsistency());
+        request.putQueryParam(STRONG_CONSISTENCY, params.hasStrongConsistency());
         return request;
     }
 
@@ -187,6 +189,7 @@ public abstract class InternalC8KeyValue<A extends InternalC8DB<E>, D extends In
         if (StringUtils.isNotEmpty(params.getGroup())) {
             request.putQueryParam(GROUP_ID, params.getGroup());
         }
+        request.putQueryParam(STRONG_CONSISTENCY, params.hasStrongConsistency());
         return request;
     }
 
@@ -275,10 +278,11 @@ public abstract class InternalC8KeyValue<A extends InternalC8DB<E>, D extends In
 
     protected Request truncateRequest(C8KVTruncateOptions options) {
         final Request request = request(db.tenant(), db.name(), RequestType.PUT, PATH_API_KV, name, PATH_API_KV_TRUNCATE);
-        if (options != null && StringUtils.isNotEmpty(options.getGroup())) {
-            request.putQueryParam(GROUP_ID, options.getGroup());
+        final C8KVTruncateOptions params = (options != null ? options : new C8KVTruncateOptions());
+        if (StringUtils.isNotEmpty(params.getGroup())) {
+            request.putQueryParam(GROUP_ID, params.getGroup());
         }
-        request.putQueryParam(STRONG_CONSISTENCY, options != null && options.hasStrongConsistency());
+        request.putQueryParam(STRONG_CONSISTENCY, params.hasStrongConsistency());
         return request;
     }
 

--- a/src/main/java/com/c8db/model/C8KVCountPairsOptions.java
+++ b/src/main/java/com/c8db/model/C8KVCountPairsOptions.java
@@ -3,4 +3,5 @@
  */
 package com.c8db.model;
 
-public class C8KVCountPairsOptions extends MixinBase implements GroupIdMixin<C8KVCountPairsOptions> {}
+public class C8KVCountPairsOptions extends MixinBase implements GroupIdMixin<C8KVCountPairsOptions>,
+        StrongConsistencyMixin<C8KVCountPairsOptions> {}

--- a/src/main/java/com/c8db/model/C8KVReadKeysOptions.java
+++ b/src/main/java/com/c8db/model/C8KVReadKeysOptions.java
@@ -4,4 +4,4 @@
 package com.c8db.model;
 
 public class C8KVReadKeysOptions extends MixinBase implements PaginationMixin<C8KVReadKeysOptions>,
-        SortMixin<C8KVReadKeysOptions>, GroupIdMixin<C8KVReadKeysOptions> {}
+        SortMixin<C8KVReadKeysOptions>, GroupIdMixin<C8KVReadKeysOptions>, StrongConsistencyMixin<C8KVReadKeysOptions> {}


### PR DESCRIPTION
Added `strongConsistency` optional query parameter to `kv/count`, `kv/keys` regarding the comment https://macrometa.atlassian.net/browse/C84J-17?focusedCommentId=57873