### PR TITLE
[1.25.24] CEP-566: Fix data loss in SW. Add Retry to HttpCommunication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.25.25</version>
+    <version>1.1.25.26-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.25.25</tag>
+        <tag>c84j-1.1.25.1</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.25.25-SNAPSHOT</version>
+    <version>1.1.25.25</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.25.1</tag>
+        <tag>c84j-1.1.25.25</tag>
     </scm>
 
     <organization>

--- a/src/main/java/com/c8db/C8DB.java
+++ b/src/main/java/com/c8db/C8DB.java
@@ -322,6 +322,17 @@ public interface C8DB extends C8SerializationAccessor {
         }
 
         /**
+         * Sets the retry timeout in milliseconds.
+         *
+         * @param retryTimeout timeout in milliseconds
+         * @return {@link C8DB.Builder}
+         */
+        public Builder retryTimeout(final Integer retryTimeout) {
+            setRetryTimeout(retryTimeout);
+            return this;
+        }
+
+        /**
          * Register a custom {@link VPackSerializer} for a specific type to be used
          * within the internal serialization process.
          *
@@ -664,7 +675,7 @@ public interface C8DB extends C8SerializationAccessor {
             final ConnectionFactory connectionFactory = (protocol == null || Protocol.VST == protocol)
                     ? new VstConnectionFactorySync(timeout, connectionTtl, useSsl, sslContext)
                     : new HttpConnectionFactory(timeout, responseSizeLimit, user, password, email, jwtAuth, useSsl, sslContext, custom, protocol,
-                            connectionTtl, httpCookieSpec, jwtToken, apiKey, hosts.get(Service.C8DB).get(0));
+                            connectionTtl, httpCookieSpec, jwtToken, apiKey, hosts.get(Service.C8DB).get(0), retryTimeout);
 
             final Map<Service, Collection<Host>> hostsMatrix = createHostMatrix(max, connectionFactory);
             final HostResolver hostResolver = createHostResolver(hostsMatrix, max, connectionFactory);
@@ -673,7 +684,8 @@ public interface C8DB extends C8SerializationAccessor {
                     new VstCommunicationSync.Builder(hostHandlerMatrix).timeout(timeout).user(user).password(password)
                             .useSsl(useSsl).sslContext(sslContext).chunksize(chunksize).maxConnections(maxConnections)
                             .connectionTtl(connectionTtl),
-                    new HttpCommunication.Builder(hostHandlerMatrix), util, protocol, hostResolver, new C8Context());
+                    new HttpCommunication.Builder(hostHandlerMatrix), util, protocol, hostResolver,
+                    new C8Context());
         }
 
     }

--- a/src/main/java/com/c8db/internal/C8Defaults.java
+++ b/src/main/java/com/c8db/internal/C8Defaults.java
@@ -52,5 +52,5 @@ public final class C8Defaults {
     public static final boolean DEFAULT_ACQUIRE_HOST_LIST = false;
     public static final int DEFAULT_ACQUIRE_HOST_LIST_INTERVAL = 60 * 60 * 1000; // hour
     public static final LoadBalancingStrategy DEFAULT_LOAD_BALANCING_STRATEGY = LoadBalancingStrategy.NONE;
-
+    public static final Integer DEFAULT_RETRY_TIMEOUT = 256000;
 }

--- a/src/main/java/com/c8db/internal/InternalC8DBBuilder.java
+++ b/src/main/java/com/c8db/internal/InternalC8DBBuilder.java
@@ -66,6 +66,7 @@ public abstract class InternalC8DBBuilder {
     private static final String PROPERTY_KEY_HOST = "c8db.host";
     private static final String PROPERTY_KEY_PORT = "c8db.port";
     private static final String PROPERTY_KEY_TIMEOUT = "c8db.timeout";
+    private static final String PROPERTY_KEY_RETRY_TIMEOUT = "c8db.retryTimeout";
     private static final String PROPERTY_KEY_RESPONSE_SIZE_LIMIT = "c8db.responseSizeLimit";
     private static final String PROPERTY_KEY_USER = "c8db.user";
     private static final String PROPERTY_KEY_PASSWORD = "c8db.password";
@@ -105,6 +106,7 @@ public abstract class InternalC8DBBuilder {
     protected Boolean acquireHostList;
     protected Integer acquireHostListInterval;
     protected LoadBalancingStrategy loadBalancingStrategy;
+    protected Integer retryTimeout;
     protected C8Serialization customSerializer;
     protected String apiKey;
 
@@ -164,6 +166,7 @@ public abstract class InternalC8DBBuilder {
         acquireHostList = loadAcquireHostList(properties, acquireHostList);
         acquireHostListInterval = loadAcquireHostListInterval(properties, acquireHostListInterval);
         loadBalancingStrategy = loadLoadBalancingStrategy(properties, loadBalancingStrategy);
+        retryTimeout = loadRetryTimeout(properties, retryTimeout);
     }
 
     protected void setHost(final Service service, final String host, final int port) {
@@ -270,6 +273,9 @@ public abstract class InternalC8DBBuilder {
         LOG.debug("HostHandler is " + hostHandler.getClass().getSimpleName());
 
         return new DirtyReadHostHandler(hostHandler, new RoundRobinHostHandler(hostResolver, service));
+    }
+    protected void setRetryTimeout(final Integer retryTimeout) {
+        this.retryTimeout = retryTimeout;
     }
 
     protected void deserializer(final C8Deserializer deserializer) {
@@ -403,6 +409,12 @@ public abstract class InternalC8DBBuilder {
             final LoadBalancingStrategy currentValue) {
         return LoadBalancingStrategy.valueOf(getProperty(properties, PROPERTY_KEY_LOAD_BALANCING_STRATEGY, currentValue,
                 C8Defaults.DEFAULT_LOAD_BALANCING_STRATEGY).toUpperCase());
+    }
+
+    private static Integer loadRetryTimeout(final Properties properties, final Integer currentValue) {
+        return Integer
+                .parseInt(getProperty(properties, PROPERTY_KEY_RETRY_TIMEOUT, currentValue,
+                        C8Defaults.DEFAULT_RETRY_TIMEOUT));
     }
 
     protected static <T> String getProperty(final Properties properties, final String key, final T currentValue,

--- a/src/main/java/com/c8db/internal/http/HttpConnection.java
+++ b/src/main/java/com/c8db/internal/http/HttpConnection.java
@@ -65,6 +65,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.ConnectException;
 import java.net.UnknownHostException;
 import java.nio.charset.CodingErrorAction;
 import java.util.ArrayList;
@@ -303,7 +304,7 @@ public class HttpConnection implements Connection {
             } else {
                 checkError(response);
             }
-        } catch (UnknownHostException | NoHttpResponseException ex) {
+        } catch (UnknownHostException | NoHttpResponseException | ConnectException ex) {
             response = retryRequest(request, httpRequest);
             if(response == null){
                 throw new C8DBException("c84j exhausted all retries.", SC_SERVICE_UNAVAILABLE, ex);

--- a/src/main/java/com/c8db/internal/http/HttpConnectionFactory.java
+++ b/src/main/java/com/c8db/internal/http/HttpConnectionFactory.java
@@ -35,13 +35,13 @@ public class HttpConnectionFactory implements ConnectionFactory {
     public HttpConnectionFactory(final Integer timeout, final Integer responseSizeLimit, final String user, final String password, final String email,
             final Boolean jwtAuth, final Boolean useSsl, final SSLContext sslContext, final C8Serialization util,
             final Protocol protocol, final Long connectionTtl, String httpCookieSpec, final String jwtToken, final String apiKey,
-                                 final HostDescription auxiliaryHost) {
+                                 final HostDescription auxiliaryHost, Integer retryTimeout) {
         super();
         builder = new HttpConnection.Builder().timeout(timeout).responseSizeLimit(responseSizeLimit).user(user)
                 .password(password).email(email)
                 .jwtAuthEnabled(jwtAuth).useSsl(useSsl).sslContext(sslContext).serializationUtil(util)
                 .contentType(protocol).ttl(connectionTtl).httpCookieSpec(httpCookieSpec).jwt(jwtToken)
-                .apiKey(apiKey).auxHost(auxiliaryHost);
+                .apiKey(apiKey).auxHost(auxiliaryHost).retryTimeout(retryTimeout);
     }
 
     @Override

--- a/src/main/java/com/c8db/util/BackoffRetryCounter.java
+++ b/src/main/java/com/c8db/util/BackoffRetryCounter.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2023 Macrometa Corp All rights reserved.
+ */
+package com.c8db.util;
+
+public interface BackoffRetryCounter {
+
+    /**
+     * Reset counter to initial position
+     */
+    void reset();
+
+    /**
+     * Check if retry possible
+     */
+    boolean canRetry();
+
+    /**
+     * Increment counter after retry
+     */
+    void increment();
+
+    /**
+     * @return time in milliseconds for current retry
+     */
+    long getTimeIntervalMillis();
+
+    /**
+     * @return time interval in human-readable format
+     */
+    String getTimeInterval();
+}

--- a/src/main/java/com/c8db/util/RequestBackoffRetryCounter.java
+++ b/src/main/java/com/c8db/util/RequestBackoffRetryCounter.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2023 Macrometa Corp All rights reserved.
+ */
+package com.c8db.util;
+
+import com.c8db.velocystream.Request;
+
+/**
+ * Backoff Retry Counter to count when to retry next during reconnection
+ */
+public class RequestBackoffRetryCounter implements BackoffRetryCounter {
+
+    public static final int INITIAL_SLEEP_TIME_SEC = 4;
+    public static final int SLEEP_TIME_MULTIPLIER = 2;
+    private static final int MAX_SLEEP_TIME_SEC = 128;
+
+    private Request request;
+    private int currentWaitTime;
+
+    public RequestBackoffRetryCounter(Request request) {
+        this.request = request;
+        this.currentWaitTime = INITIAL_SLEEP_TIME_SEC;
+    }
+
+    public synchronized void reset() {
+        currentWaitTime = INITIAL_SLEEP_TIME_SEC;
+    }
+
+    public synchronized boolean canRetry() {
+        return request.isRetryEnabled() && currentWaitTime <= MAX_SLEEP_TIME_SEC;
+    }
+
+    public synchronized void increment() {
+        currentWaitTime *= SLEEP_TIME_MULTIPLIER;
+    }
+
+    public long getTimeIntervalMillis() {
+        return currentWaitTime * 1000L;
+    }
+
+    public String getTimeInterval() {
+        return currentWaitTime + " seconds";
+    }
+}

--- a/src/main/java/com/c8db/util/RequestBackoffRetryCounter.java
+++ b/src/main/java/com/c8db/util/RequestBackoffRetryCounter.java
@@ -12,13 +12,19 @@ public class RequestBackoffRetryCounter implements BackoffRetryCounter {
 
     public static final int INITIAL_SLEEP_TIME_SEC = 4;
     public static final int SLEEP_TIME_MULTIPLIER = 2;
-    private static final int MAX_SLEEP_TIME_SEC = 128;
+    private static final int DEFAULT_MAX_SLEEP_TIME_SEC = 128;
 
-    private Request request;
+    private final Request request;
+    private final int maxSleepTimeSec;
     private int currentWaitTime;
 
-    public RequestBackoffRetryCounter(Request request) {
+    public RequestBackoffRetryCounter(Request request, Integer retryTimeout) {
         this.request = request;
+        if (retryTimeout != null) {
+            maxSleepTimeSec = retryTimeout / 1000 / 2;
+        } else {
+            maxSleepTimeSec = DEFAULT_MAX_SLEEP_TIME_SEC;
+        }
         this.currentWaitTime = INITIAL_SLEEP_TIME_SEC;
     }
 
@@ -27,7 +33,7 @@ public class RequestBackoffRetryCounter implements BackoffRetryCounter {
     }
 
     public synchronized boolean canRetry() {
-        return request.isRetryEnabled() && currentWaitTime <= MAX_SLEEP_TIME_SEC;
+        return request.isRetryEnabled() && currentWaitTime <= maxSleepTimeSec;
     }
 
     public synchronized void increment() {


### PR DESCRIPTION
The issue was because of the next exception:
```
2023-10-19 22:41:59,034877 ERROR StreamHandler.onError(StreamHandler.java:95) - thread_name="C8CEP-T-MHwHnrgAI3DBMwf35fXUQ-.root._system.sw-db-restart3-executor-thread-0" - [AppId: T-MHwHnrgAI3DBMwf35fXUQ-.root._system.sw-db-restart3]  Error in SiddhiApp 'T-MHwHnrgAI3DBMwf35fXUQ-:root:_system:sw-db-restart3' after consuming events from Stream 'ExternlPulsarStream1', com.c8db.C8DBException: Cannot contact any host!. Hence, dropping event 'Event{timestamp=1697755319023, data=[22222], isExpired=false}' com.c8db.C8DBException: Cannot contact any host!?	
at com.c8db.internal.net.FallbackHostHandler.get(FallbackHostHandler.java:50) ~[c84j-1.1.25.23.jar!/:?]?	
at com.c8db.internal.net.DirtyReadHostHandler.get(DirtyReadHostHandler.java:48) ~[c84j-1.1.25.23.jar!/:?]?	
at com.c8db.internal.http.HttpCommunication.execute(HttpCommunication.java:101) ~[c84j-1.1.25.23.jar!/:?]?	
at com.c8db.internal.http.HttpProtocol.execute(HttpProtocol.java:45) ~[c84j-1.1.25.23.jar!/:?]?	
at com.c8db.internal.C8ExecutorSync.execute(C8ExecutorSync.java:83) ~[c84j-1.1.25.23.jar!/:?]?	
at com.c8db.internal.C8ExecutorSync.execute(C8ExecutorSync.java:75) ~[c84j-1.1.25.23.jar!/:?]?	
at com.c8db.internal.C8ExecutorSync.execute(C8ExecutorSync.java:70) ~[c84j-1.1.25.23.jar!/:?]?	
at com.c8db.internal.C8CollectionImpl.insertDocuments(C8CollectionImpl.java:194) ~[c84j-1.1.25.23.jar!/:?]?	
at co.macrometa.c8cep.extension.util.C8DocumentManager.addRecords(C8DocumentManager.java:114) ~[classes!/:?]?	
at co.macrometa.c8cep.extension.util.C8CollectionManager.addRecords(C8CollectionManager.java:64) ~[classes!/:?]?	
at co.macrometa.c8cep.extension.store.DatabaseEventTable.addBatchRecords(DatabaseEventTable.java:445) ~[classes!/:?]?	
at co.macrometa.c8cep.extension.store.DatabaseEventTable.add(DatabaseEventTable.java:426) ~[classes!/:?]?	... 17 more?Wrapped by: io.siddhi.core.exception.DatabaseRuntimeException: com.c8db.C8DBException: Cannot contact any host!?	
at co.macrometa.c8cep.extension.store.DatabaseEventTable.handleC8DBExceptionForAddOperation(DatabaseEventTable.java:778) ~[classes!/:?]?	
at co.macrometa.c8cep.extension.store.DatabaseEventTable.add(DatabaseEventTable.java:431) ~[classes!/:?]?	
at io.siddhi.core.table.record.AbstractRecordTable.add(AbstractRecordTable.java:116) ~[c8cep-core-5.1.22.2-SNAPSHOT.jar!/:?]?	
at io.siddhi.core.table.Table.addEvents(Table.java:282) ~[c8cep-core-5.1.22.2-SNAPSHOT.jar!/:?]?	
at io.siddhi.core.query.output.callback.InsertIntoTableCallback.send(InsertIntoTableCallback.java:73) ~[c8cep-core-5.1.22.2-SNAPSHOT.jar!/:?]?	
at io.siddhi.core.query.output.ratelimit.OutputRateLimiter.sendToCallBacks(OutputRateLimiter.java:104) ~[c8cep-core-5.1.22.2-SNAPSHOT.jar!/:?]?	
at io.siddhi.core.query.output.ratelimit.PassThroughOutputRateLimiter.process(PassThroughOutputRateLimiter.java:45) ~[c8cep-core-5.1.22.2-SNAPSHOT.jar!/:?]?	
at io.siddhi.core.query.selector.QuerySelector.process(QuerySelector.java:99) ~[c8cep-core-5.1.22.2-SNAPSHOT.jar!/:?]?	
at io.siddhi.core.query.input.ProcessStreamReceiver.processAndClear(ProcessStreamReceiver.java:182) ~[c8cep-core-5.1.22.2-SNAPSHOT.jar!/:?]?	
at io.siddhi.core.query.input.ProcessStreamReceiver.process(ProcessStreamReceiver.java:84) ~[c8cep-core-5.1.22.2-SNAPSHOT.jar!/:?]?	
at io.siddhi.core.query.input.ProcessStreamReceiver.receive(ProcessStreamReceiver.java:166) ~[c8cep-core-5.1.22.2-SNAPSHOT.jar!/:?]?	
at io.siddhi.core.util.event.handler.StreamHandler.onEvent(StreamHandler.java:66) ~[c8cep-core-5.1.22.2-SNAPSHOT.jar!/:?]?	
at io.siddhi.core.util.event.handler.StreamHandler.onEvent(StreamHandler.java:35) ~[c8cep-core-5.1.22.2-SNAPSHOT.jar!/:?]?	
at com.lmax.disruptor.BatchEventProcessor.processEvents(BatchEventProcessor.java:168) ~[disruptor-3.4.2.wso2v1.jar!/:?]?	
at com.lmax.disruptor.BatchEventProcessor.run(BatchEventProcessor.java:125) ~[disruptor-3.4.2.wso2v1.jar!/:?]?	
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]?	
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]?	
at java.lang.Thread.run(Thread.java:829) ~[?:?]?	
at io.siddhi.core.util.parser.SiddhiAppParser$1$1.run(SiddhiAppParser.java:488) ~[c8cep-core-5.1.22.2-SNAPSHOT.jar!/:?]?
```

Important note:  dropping messages happens when SW has a big batch of 512 messages. Also, it is not important how many `@App:instances(N)` it has.

Why it happens? 

c84j driver calls for a new communication in HttpCommunication which cannot be established because it doesn't wait any time before the next retry. Such logic was implemented in `HttpConnection`.

Solution
Decouple the retry logic from `HttpConnection` class and add it to `HttpCommunication`.

Important note 2: This retry counter cannot retry infinity times. If `c8db` is offline more time than period then SW throws `Hence, dropping event` and it is the correct approach. It will be solved by adding a Failed/Error stream that catches dropped messages.