### PR TITLE
[1.1.25] C84j-19: Fix ERROR_STREAM_ALREADY_EXISTS to 1210

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.25.24-SNAPSHOT</version>
+    <version>1.1.25.24</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.25.1</tag>
+        <tag>c84j-1.1.25.24</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.25.24</version>
+    <version>1.1.25.25-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.25.24</tag>
+        <tag>c84j-1.1.25.1</tag>
     </scm>
 
     <organization>

--- a/src/main/java/com/c8db/internal/C8Errors.java
+++ b/src/main/java/com/c8db/internal/C8Errors.java
@@ -28,7 +28,7 @@ public final class C8Errors {
     public static final Integer ERROR_C8_DATA_SOURCE_NOT_FOUND = 1203;
     public static final Integer ERROR_C8_DATABASE_NOT_FOUND = 1228;
     public static final Integer ERROR_GRAPH_NOT_FOUND = 1924;
-    public static final Integer ERROR_STREAM_ALREADY_EXISTS = 100017;
+    public static final Integer ERROR_STREAM_ALREADY_EXISTS = 1210;
     public static final Integer ERROR_STREAM_NOT_FOUND = 100016;
     public static final Integer ERROR_COLLECTION_ALREADY_EXISTS = 1207;
 


### PR DESCRIPTION
Fix `ERROR_STREAM_ALREADY_EXISTS` variable to `1210` in class `C8Errors`.