### PR TITLE
C84J-19: Fix ERROR_STREAM_ALREADY_EXISTS to 1210

### DIFF
--- a/src/main/java/com/c8db/internal/C8Errors.java
+++ b/src/main/java/com/c8db/internal/C8Errors.java
@@ -28,7 +28,7 @@ public final class C8Errors {
     public static final Integer ERROR_C8_DATA_SOURCE_NOT_FOUND = 1203;
     public static final Integer ERROR_C8_DATABASE_NOT_FOUND = 1228;
     public static final Integer ERROR_GRAPH_NOT_FOUND = 1924;
-    public static final Integer ERROR_STREAM_ALREADY_EXISTS = 100017;
+    public static final Integer ERROR_STREAM_ALREADY_EXISTS = 1210;
     public static final Integer ERROR_STREAM_NOT_FOUND = 100016;
     public static final Integer ERROR_COLLECTION_ALREADY_EXISTS = 1207;
 


### PR DESCRIPTION
Fix `ERROR_STREAM_ALREADY_EXISTS` variable to `1210` in class `C8Errors`.