### PR TITLE
[1.1.25] C84J-20: Fix default HTTP connections to 20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.25.26</version>
+    <version>1.1.25.27-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.25.26</tag>
+        <tag>c84j-1.1.25.1</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.25.26-SNAPSHOT</version>
+    <version>1.1.25.26</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -334,7 +334,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.25.1</tag>
+        <tag>c84j-1.1.25.26</tag>
     </scm>
 
     <organization>

--- a/src/main/java/com/c8db/internal/InternalC8DBBuilder.java
+++ b/src/main/java/com/c8db/internal/InternalC8DBBuilder.java
@@ -385,8 +385,9 @@ public abstract class InternalC8DBBuilder {
     }
 
     private static Integer loadMaxConnections(final Properties properties, final Integer currentValue) {
-        return Integer.parseInt(getProperty(properties, PROPERTY_KEY_MAX_CONNECTIONS, currentValue,
-                C8Defaults.MAX_CONNECTIONS_VST_DEFAULT));
+        final String max = getProperty(properties, PROPERTY_KEY_MAX_CONNECTIONS, currentValue,
+                null);
+        return max != null ? Integer.parseInt(max) : null;
     }
 
     private static Long loadConnectionTtl(final Properties properties, final Long currentValue) {


### PR DESCRIPTION
Now, the default number of HTTP connections is `1` 
But default should be `20`