### PR TITLE
CEP-658: Fixed SecretProvider for secrets. Removed workaround for fx.

### DIFF
--- a/bin/pom.xml
+++ b/bin/pom.xml
@@ -62,7 +62,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.5</version>
+				<version>1.6.13</version>
 				<extensions>true</extensions>
 				<configuration>
 					<serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.41-SNAPSHOT</version>
+    <version>1.1.41</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -347,7 +347,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.25</tag>
+        <tag>c84j-1.1.41</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.41</version>
+    <version>1.1.42-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -347,7 +347,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.41</tag>
+        <tag>c84j-1.1.25</tag>
     </scm>
 
     <organization>

--- a/src/main/java/com/c8db/internal/C8Executeable.java
+++ b/src/main/java/com/c8db/internal/C8Executeable.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modifications copyright (c) 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal;
@@ -37,12 +39,15 @@ public abstract class C8Executeable<E extends C8Executor> {
     protected final E executor;
     protected final C8SerializationFactory util;
     protected final C8Context context;
+    protected final String dbTenant;
 
-    protected C8Executeable(final E executor, final C8SerializationFactory util, final C8Context context) {
+    protected C8Executeable(final E executor, final C8SerializationFactory util, final C8Context context,
+                            final String dbTenant) {
         super();
         this.executor = executor;
         this.util = util;
         this.context = context;
+        this.dbTenant = dbTenant;
     }
 
     protected E executor() {
@@ -57,14 +62,14 @@ public abstract class C8Executeable<E extends C8Executor> {
         return util.get(serializer);
     }
 
-    protected Request request(final String tenant, final String database, final RequestType requestType,
+    protected Request request(final String pathTenant, final String pathDatabase, final RequestType requestType,
                               final String... path) {
-        return request(tenant, database, requestType, true, path);
+        return request(pathTenant, pathDatabase, requestType, true, path);
     }
 
-    protected Request request(final String tenant, final String database, final RequestType requestType,
+    protected Request request(final String pathTenant, final String pathDatabase, final RequestType requestType,
             final boolean retryEnabled, final String... path) {
-        final Request request = new Request(tenant, database, requestType, retryEnabled, createPath(path));
+        final Request request = new Request(dbTenant, pathTenant, pathDatabase, requestType, retryEnabled, createPath(path));
         for (final Entry<String, String> header : context.getHeaderParam().entrySet()) {
             request.putHeaderParam(header.getKey(), header.getValue());
         }

--- a/src/main/java/com/c8db/internal/C8RemoteSecretProvider.java
+++ b/src/main/java/com/c8db/internal/C8RemoteSecretProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Macrometa Corp All rights reserved
+ * Copyright (c) 2022 - 2024 Macrometa Corp All rights reserved
  */
 
 package com.c8db.internal;
@@ -62,7 +62,7 @@ public class C8RemoteSecretProvider implements SecretProvider {
         credentials.put("password", new String(password));
         credentials.put("email", email);
         final HttpRequestBase authHttpRequest = RequestUtils.buildHttpRequestBase(
-            new Request(null, null, RequestType.POST, authUrl)
+            new Request(null, null, null, RequestType.POST, authUrl)
                 .setBody(serialization.serialize(credentials)), authUrl, contentType);
         authHttpRequest.setHeader(HttpHeaders.USER_AGENT,
             "Mozilla/5.0 (compatible; C8DB-JavaDriver/1.1; +http://mt.orz.at/)");

--- a/src/main/java/com/c8db/internal/InternalC8Admin.java
+++ b/src/main/java/com/c8db/internal/InternalC8Admin.java
@@ -25,6 +25,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+
+import static com.c8db.internal.InternalC8ApiKeys.SYSTEM_TENANT;
 
 /**
  * Internal request/response related functions.
@@ -129,7 +132,12 @@ public abstract class InternalC8Admin<A extends InternalC8DB<E>, D extends Inter
     }
     
     protected Request getTenantFeaturesRequest(final String tenant) {
-        return request(db.tenant(), db.name(), RequestType.GET, PATH_API_FEATURES, PATH_TENANT, tenant);
+        final Request request = new Request(SYSTEM_TENANT, null, null, RequestType.GET, true,
+                createPath(PATH_API_FEATURES, PATH_TENANT, tenant));
+        for (final Map.Entry<String, String> header : context.getHeaderParam().entrySet()) {
+            request.putHeaderParam(header.getKey(), header.getValue());
+        }
+        return request;
     }
 
     protected Request getTenantMetricsRequest(TenantMetricsOption options){

--- a/src/main/java/com/c8db/internal/InternalC8Admin.java
+++ b/src/main/java/com/c8db/internal/InternalC8Admin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Macrometa Corp All rights reserved.
+ * Copyright (c) 2021 - 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal;
@@ -45,7 +45,7 @@ public abstract class InternalC8Admin<A extends InternalC8DB<E>, D extends Inter
     private final D db;
 
     protected InternalC8Admin(final D db) {
-        super(db.executor, db.util, db.context);
+        super(db.executor, db.util, db.context, db.tenant());
         this.db = db;
     }
 

--- a/src/main/java/com/c8db/internal/InternalC8Alerts.java
+++ b/src/main/java/com/c8db/internal/InternalC8Alerts.java
@@ -1,7 +1,5 @@
 /*
- *
- *  * Copyright (c) 2022 Macrometa Corp All rights reserved
- *
+ * Copyright (c) 2022 - 2024 Macrometa Corp All rights reserved
  */
 
 package com.c8db.internal;
@@ -28,7 +26,7 @@ public abstract class InternalC8Alerts<A extends InternalC8DB<E>, D extends Inte
     private final D db;
 
     protected InternalC8Alerts(final D db) {
-        super(db.executor, db.util, db.context);
+        super(db.executor, db.util, db.context, db.tenant());
         this.db = db;
     }
 

--- a/src/main/java/com/c8db/internal/InternalC8ApiKeys.java
+++ b/src/main/java/com/c8db/internal/InternalC8ApiKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Macrometa Corp All rights reserved.
+ * Copyright (c) 2021 - 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal;
@@ -41,7 +41,7 @@ public abstract class InternalC8ApiKeys<A extends InternalC8DB<E>, D extends Int
     private final D db;
 
     public InternalC8ApiKeys(D db) {
-        super(db.executor, db.util, db.context);
+        super(db.executor, db.util, db.context, db.tenant());
         this.db = db;
     }
 

--- a/src/main/java/com/c8db/internal/InternalC8Collection.java
+++ b/src/main/java/com/c8db/internal/InternalC8Collection.java
@@ -13,8 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Modifications copyright (c) 2021 Macrometa Corp All rights reserved.
- *
+ * Modifications copyright (c) 2021 - 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal;
@@ -96,7 +95,7 @@ public abstract class InternalC8Collection<A extends InternalC8DB<E>, D extends 
     protected volatile String name;
 
     protected InternalC8Collection(final D db, final String name) {
-        super(db.executor, db.util, db.context);
+        super(db.executor, db.util, db.context, db.tenant());
         this.db = db;
         this.name = name;
     }

--- a/src/main/java/com/c8db/internal/InternalC8Compute.java
+++ b/src/main/java/com/c8db/internal/InternalC8Compute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Macrometa Corp All rights reserved.
+ * Copyright (c) 2021 - 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal;
@@ -15,9 +15,7 @@ import com.c8db.velocystream.Request;
 import com.c8db.velocystream.RequestType;
 import com.c8db.velocystream.Response;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -25,20 +23,18 @@ import java.util.Map;
  */
 public abstract class InternalC8Compute<A extends InternalC8DB<E>, D extends InternalC8Database<A, E>, E extends C8Executor>
     extends C8Executeable<E> {
-
-    protected static final String PATH_API_COMPUTE = "/_api/compute";
-    protected static final String PATH_API_FX = PATH_API_COMPUTE + "/fx";
+    protected static final String PATH_API_FUNCTION = "/_api/function";
     protected static final String METADATA = "metadata";
 
     private final D db;
 
     public InternalC8Compute(D db) {
-        super(db.executor, db.util, db.context);
+        super(db.executor, db.util, db.context, db.tenant());
         this.db = db;
     }
 
     protected Request getFunctionsRequest(final FxReadOptions options) {
-        final Request request = request(db.tenant(), db.name(), RequestType.GET, PATH_API_FX);
+        final Request request = request(null, db.name(), RequestType.GET, PATH_API_FUNCTION);
         final FxReadOptions params = (options != null ? options : new FxReadOptions());
         request.putQueryParam("type", params.getType().toString().toLowerCase());
         return request;
@@ -56,7 +52,7 @@ public abstract class InternalC8Compute<A extends InternalC8DB<E>, D extends Int
     }
 
     protected Request getInfoRequest(final String name) {
-        final Request request = request(db.tenant(), db.name(), RequestType.GET, PATH_API_FX, name);
+        final Request request = request(null, db.name(), RequestType.GET, PATH_API_FUNCTION, name);
         return request;
     }
 
@@ -73,8 +69,7 @@ public abstract class InternalC8Compute<A extends InternalC8DB<E>, D extends Int
     }
 
     protected Request getMetadataRequest() {
-        final Request request = request(db.tenant(), db.name(), RequestType.GET, PATH_API_FX, METADATA);
-        return request;
+        return request(null, db.name(), RequestType.GET, PATH_API_FUNCTION, METADATA);
     }
 
     protected ResponseDeserializer<FxMetadataEntity> getMetadataResponseDeserializer() {
@@ -90,7 +85,7 @@ public abstract class InternalC8Compute<A extends InternalC8DB<E>, D extends Int
 
     protected Request executeFunctionRequest(String name, Map<String, Object> arguments) {
         final VPackSlice body = util().serialize(arguments);
-        final Request request = request(db.tenant(), db.name(), RequestType.POST, false, PATH_API_FX, "invoke", name);
+        final Request request = request(null, db.name(), RequestType.POST, false, PATH_API_FUNCTION, "invoke", name);
         request.putQueryParam("params", body.toString());
         return request;
     }

--- a/src/main/java/com/c8db/internal/InternalC8DB.java
+++ b/src/main/java/com/c8db/internal/InternalC8DB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Macrometa Corp All rights reserved
+ * Copyright (c) 2021 - 2024 Macrometa Corp All rights reserved
  */
 
 package com.c8db.internal;
@@ -16,7 +16,6 @@ import com.arangodb.velocypack.exception.VPackException;
 import com.c8db.entity.DataCenterEntity;
 import com.c8db.entity.DcInfoEntity;
 import com.c8db.entity.GeoFabricEntity;
-import com.c8db.entity.GeoFabricPermissions;
 import com.c8db.entity.LogLevelEntity;
 import com.c8db.entity.Permissions;
 import com.c8db.entity.ServerRole;
@@ -34,8 +33,8 @@ import com.c8db.velocystream.Request;
 import com.c8db.velocystream.RequestType;
 import com.c8db.velocystream.Response;
 
+import static com.c8db.internal.InternalC8ApiKeys.SYSTEM_TENANT;
 import static com.c8db.internal.InternalC8Database.QUERY_PARAM_FULL;
-
 
 public abstract class InternalC8DB<E extends C8Executor> extends C8Executeable<E> {
 
@@ -45,7 +44,7 @@ public abstract class InternalC8DB<E extends C8Executor> extends C8Executeable<E
     private static final String PATH_API_ROLE = "/_admin/server/role";
 
     protected InternalC8DB(final E executor, final C8SerializationFactory util, final C8Context context) {
-        super(executor, util, context);
+        super(executor, util, context, SYSTEM_TENANT);
     }
 
     protected Request getRoleRequest() {

--- a/src/main/java/com/c8db/internal/InternalC8Database.java
+++ b/src/main/java/com/c8db/internal/InternalC8Database.java
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Modifications copyright (c) 2021 Macrometa Corp All rights reserved.
- *
+ * Modifications copyright (c) 2021 - 2024 Macrometa Corp All rights reserved.
+
  */
 
 package com.c8db.internal;
@@ -113,7 +113,7 @@ public abstract class InternalC8Database<A extends InternalC8DB<E>, E extends C8
 
     protected InternalC8Database(final A c8db, final String tenant, final String name, final String spotDc,
                                  final String dcList) {
-        super(c8db.executor, c8db.util, c8db.context);
+        super(c8db.executor, c8db.util, c8db.context, c8db.dbTenant);
         this.c8db = c8db;
         this.tenant = tenant;
         this.name = name;

--- a/src/main/java/com/c8db/internal/InternalC8Dynamo.java
+++ b/src/main/java/com/c8db/internal/InternalC8Dynamo.java
@@ -1,7 +1,5 @@
 /*
- *
- * Copyright (c) 2022 Macrometa Corp All rights reserved
- *
+ * Copyright (c) 2022 - 2024 Macrometa Corp All rights reserved
  */
 package com.c8db.internal;
 
@@ -95,7 +93,7 @@ public abstract class InternalC8Dynamo<A extends InternalC8DB<E>, D extends Inte
     }
 
     protected InternalC8Dynamo(final D db, final String tableName) {
-        super(db.executor, db.util, db.context);
+        super(db.executor, db.util, db.context, db.tenant());
         this.db = db;
         this.tableName = tableName;
         this.protocolFactory = new SdkJsonProtocolFactory((new JsonClientMetadata()));

--- a/src/main/java/com/c8db/internal/InternalC8EdgeCollection.java
+++ b/src/main/java/com/c8db/internal/InternalC8EdgeCollection.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modifications copyright (c) 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal;
@@ -47,7 +49,7 @@ public abstract class InternalC8EdgeCollection<A extends InternalC8DB<E>, D exte
     private final String name;
 
     protected InternalC8EdgeCollection(final G graph, final String name) {
-        super(graph.executor, graph.util, graph.context);
+        super(graph.executor, graph.util, graph.context, graph.db().tenant());
         this.graph = graph;
         this.name = name;
     }

--- a/src/main/java/com/c8db/internal/InternalC8Event.java
+++ b/src/main/java/com/c8db/internal/InternalC8Event.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modifications copyright (c) 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal;
@@ -44,7 +46,7 @@ public abstract class InternalC8Event<A extends InternalC8DB<E>, D extends Inter
     private final D db;
 
     protected InternalC8Event(final D db) {
-        super(db.executor, db.util, db.context);
+        super(db.executor, db.util, db.context, db.tenant());
         this.db = db;
     }
 

--- a/src/main/java/com/c8db/internal/InternalC8Graph.java
+++ b/src/main/java/com/c8db/internal/InternalC8Graph.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modifications copyright (c) 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal;
@@ -44,7 +46,7 @@ public abstract class InternalC8Graph<A extends InternalC8DB<E>, D extends Inter
     private final String name;
 
     protected InternalC8Graph(final D db, final String name) {
-        super(db.executor, db.util, db.context);
+        super(db.executor, db.util, db.context, db.tenant());
         this.db = db;
         this.name = name;
     }

--- a/src/main/java/com/c8db/internal/InternalC8KeyValue.java
+++ b/src/main/java/com/c8db/internal/InternalC8KeyValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Macrometa Corp All rights reserved.
+ * Copyright (c) 2023 - 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal;
@@ -55,7 +55,7 @@ public abstract class InternalC8KeyValue<A extends InternalC8DB<E>, D extends In
     protected volatile String name;
 
     protected InternalC8KeyValue(final D db, final String name) {
-        super(db.executor, db.util, db.context);
+        super(db.executor, db.util, db.context, db.tenant());
         this.db = db;
         this.name = name;
     }

--- a/src/main/java/com/c8db/internal/InternalC8Redis.java
+++ b/src/main/java/com/c8db/internal/InternalC8Redis.java
@@ -1,7 +1,5 @@
 /*
- *
- * Copyright (c) 2022 Macrometa Corp All rights reserved
- *
+ * Copyright (c) 2022 - 2024 Macrometa Corp All rights reserved
  */
 package com.c8db.internal;
 
@@ -29,7 +27,7 @@ public abstract class InternalC8Redis<A extends InternalC8DB<E>, D extends Inter
     }
 
     protected InternalC8Redis(final D db, final String tableName) {
-        super(db.executor, db.util, db.context);
+        super(db.executor, db.util, db.context, db.tenant());
         this.db = db;
         this.tableName = tableName;
         this.protocolFactory = new SdkJsonProtocolFactory((new JsonClientMetadata()));

--- a/src/main/java/com/c8db/internal/InternalC8Secret.java
+++ b/src/main/java/com/c8db/internal/InternalC8Secret.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Macrometa Corp All rights reserved
+ * Copyright (c) 2023 - 2024 Macrometa Corp All rights reserved
  */
 
 package com.c8db.internal;
@@ -23,7 +23,7 @@ public abstract class InternalC8Secret<A extends InternalC8DB<E>, D extends Inte
     private final D db;
 
     public InternalC8Secret(D db) {
-        super(db.executor, db.util, db.context);
+        super(db.executor, db.util, db.context, db.tenant());
         this.db = db;
     }
 

--- a/src/main/java/com/c8db/internal/InternalC8Stream.java
+++ b/src/main/java/com/c8db/internal/InternalC8Stream.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modifications copyright (c) 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal;
@@ -45,7 +47,7 @@ public abstract class InternalC8Stream<A extends InternalC8DB<E>, D extends Inte
     private final String name;
 
     protected InternalC8Stream(final D db, final String name) {
-        super(db.executor, db.util, db.context);
+        super(db.executor, db.util, db.context, db.tenant());
         this.db = db;
         this.name = name;
     }

--- a/src/main/java/com/c8db/internal/InternalC8StreamWorker.java
+++ b/src/main/java/com/c8db/internal/InternalC8StreamWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Macrometa Corp All rights reserved
+ * Copyright (c) 2023 - 2024 Macrometa Corp All rights reserved
  */
 
 package com.c8db.internal;
@@ -26,7 +26,7 @@ public abstract class InternalC8StreamWorker<A extends InternalC8DB<E>, D extend
     private final D db;
 
     public InternalC8StreamWorker(D db) {
-        super(db.executor, db.util, db.context);
+        super(db.executor, db.util, db.context, db.tenant());
         this.db = db;
     }
 

--- a/src/main/java/com/c8db/internal/InternalC8VertexCollection.java
+++ b/src/main/java/com/c8db/internal/InternalC8VertexCollection.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modifications copyright (c) 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal;
@@ -47,7 +49,7 @@ public abstract class InternalC8VertexCollection<A extends InternalC8DB<E>, D ex
     private final String name;
 
     protected InternalC8VertexCollection(final G graph, final String name) {
-        super(graph.executor, graph.util, graph.context);
+        super(graph.executor, graph.util, graph.context, graph.db().tenant());
         this.graph = graph;
         this.name = name;
     }

--- a/src/main/java/com/c8db/internal/InternalRestql.java
+++ b/src/main/java/com/c8db/internal/InternalRestql.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modifications copyright (c) 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal;
@@ -42,7 +44,7 @@ public abstract class InternalRestql<A extends InternalC8DB<E>, D extends Intern
     private final D db;
 
     protected InternalRestql(final D db) {
-        super(db.executor, db.util, db.context);
+        super(db.executor, db.util, db.context, db.tenant());
         this.db = db;
     }
 

--- a/src/main/java/com/c8db/internal/http/HttpConnection.java
+++ b/src/main/java/com/c8db/internal/http/HttpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Macrometa Corp All rights reserved
+ * Copyright (c) 2021 - 2024 Macrometa Corp All rights reserved
  */
 
 package com.c8db.internal.http;
@@ -176,9 +176,9 @@ public class HttpConnection implements Connection {
 
     private static String buildUrl(final String baseUrl, final Request request, final Service service) throws UnsupportedEncodingException {
         final StringBuilder sb = new StringBuilder().append(baseUrl);
-        final String database = request.getDatabase();
-        final String tenant = request.getTenant();
-        if (tenant != null && !tenant.isEmpty() && service != Service.C8FUNCTION) {
+        final String database = request.getPathDatabase();
+        final String tenant = request.getPathTenant();
+        if (StringUtils.isNotEmpty(tenant)) {
             sb.append("/_tenant/").append(tenant);
         }
 
@@ -247,8 +247,7 @@ public class HttpConnection implements Connection {
             httpRequest.setHeader(HttpHeaders.ACCEPT, "application/x-velocypack");
         }
         addHeader(request, httpRequest);
-        httpRequest.setHeader("x-gdn-tenantid", request.getTenant());
-        TenantUser tenantUser = new TenantUser(request.getTenant(), user);
+        TenantUser tenantUser = new TenantUser(request.getDbTenant(), user);
         if (jwtAuthEnabled) {
             String jwt = defaultJWT != null ? defaultJWT : cachedJwt.get(tenantUser);
             if (StringUtils.isNotEmpty(apiKey) && jwt == null) {  //Use API key only if API Key is provided
@@ -319,7 +318,7 @@ public class HttpConnection implements Connection {
             } catch (Exception e) {
                 if (e instanceof C8DBException && ((C8DBException) e).getResponseCode().equals(401)) {
                     // jwt might have expired refresh it
-                    String jwt = addJWT(new TenantUser(request.getTenant(), user));
+                    String jwt = addJWT(new TenantUser(request.getDbTenant(), user));
                     httpRequest.removeHeaders(HttpHeaders.AUTHORIZATION);
                     httpRequest.addHeader(HttpHeaders.AUTHORIZATION, "bearer " + jwt);
                 }

--- a/src/main/java/com/c8db/internal/net/ExtendedHostResolver.java
+++ b/src/main/java/com/c8db/internal/net/ExtendedHostResolver.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modifications copyright (c) 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal.net;
@@ -141,7 +143,8 @@ public class ExtendedHostResolver implements HostResolver {
 
         try {
 
-            response = executor.execute(new Request(C8RequestParam.DEMO_TENANT, C8RequestParam.SYSTEM, RequestType.GET,
+            response = executor.execute(new Request(C8RequestParam.DEMO_TENANT, C8RequestParam.DEMO_TENANT,
+                    C8RequestParam.SYSTEM, RequestType.GET,
                     "/_api/cluster/endpoints"), new ResponseDeserializer<Collection<String>>() {
                         @Override
                         public Collection<String> deserialize(final Response response) throws VPackException {

--- a/src/main/java/com/c8db/internal/velocypack/VPackSerializers.java
+++ b/src/main/java/com/c8db/internal/velocypack/VPackSerializers.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modifications copyright (c) 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal.velocypack;
@@ -27,7 +29,6 @@ import com.arangodb.velocypack.ValueType;
 import com.arangodb.velocypack.exception.VPackException;
 import com.c8db.entity.BaseDocument;
 import com.c8db.entity.BaseEdgeDocument;
-import com.c8db.entity.C8DynamoProjection;
 import com.c8db.entity.CollectionModel;
 import com.c8db.entity.CollectionType;
 import com.c8db.entity.DocumentField;
@@ -58,7 +59,7 @@ public class VPackSerializers {
             builder.add(attribute, ValueType.ARRAY);
             builder.add(value.getVersion());
             builder.add(value.getType());
-            builder.add(value.getDatabase());
+            builder.add(value.getPathDatabase());
             builder.add(value.getRequestType().getType());
             builder.add(value.getRequest());
             builder.add(ValueType.OBJECT);

--- a/src/main/java/com/c8db/internal/velocystream/internal/AuthenticationRequest.java
+++ b/src/main/java/com/c8db/internal/velocystream/internal/AuthenticationRequest.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Modifications copyright (c) 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal.velocystream.internal;
@@ -28,7 +30,7 @@ public class AuthenticationRequest extends Request {
     private final String encryption;// "plain"
 
     public AuthenticationRequest(final String user, final String password, final String encryption) {
-        super(null, null, null, null);
+        super(null, null, null, null, null);
         this.user = user;
         this.password = password;
         this.encryption = encryption;

--- a/src/main/java/com/c8db/velocystream/Request.java
+++ b/src/main/java/com/c8db/velocystream/Request.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Modifications copyright (c) 2023 Macrometa Corp All rights reserved.
+ * Modifications copyright (c) 2023 - 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.velocystream;
@@ -31,7 +31,8 @@ public class Request {
 
     private int version = 1;
     private int type = 1;
-    private final String tenant;
+    private final String dbTenant;
+    private final String pathTenant;
     private final String database;
     private final RequestType requestType;
     private final boolean retryEnabled;
@@ -41,14 +42,27 @@ public class Request {
     @Expose(serialize = false)
     private RequestBody body;
 
-    public Request(final String tenant, final String database, final RequestType requestType, final String path) {
-        this(tenant, database, requestType, true, path);
+    public Request(final String dbTenant, final String pathTenant, final String pathDatabase,
+                   final RequestType requestType,
+                   final String path) {
+        this(dbTenant, pathTenant, pathDatabase, requestType, true, path);
     }
 
-    public Request(final String tenant, final String database, final RequestType requestType, final boolean retryEnabled,
+    /**
+     *
+     * @param dbTenant - this attribute always not empty. It comes from c8db.db(<dbTenant>, ..)
+     * @param pathTenant  - this attribute empty if request doesn't have `/_tenant/<pathTenant>` an a request.
+     * @param database - - this attribute empty if request doesn't have `/_fabric/<fabric>` an a request.
+     * @param requestType - HTTP type of request
+     * @param retryEnabled - use retry strategy
+     * @param path - path suffix for a request
+     */
+    public Request(final String dbTenant, final String pathTenant, final String database, final RequestType requestType,
+                   final boolean retryEnabled,
                    final String path) {
         super();
-        this.tenant = tenant;
+        this.dbTenant = dbTenant;
+        this.pathTenant = pathTenant;
         this.database = database;
         this.request = path;
         this.requestType = requestType;
@@ -76,11 +90,15 @@ public class Request {
         return this;
     }
 
-    public String getTenant() {
-        return tenant;
+    public String getPathTenant() {
+        return pathTenant;
     }
 
-    public String getDatabase() {
+    public String getDbTenant() {
+        return dbTenant;
+    }
+
+    public String getPathDatabase() {
         return database;
     }
 


### PR DESCRIPTION
Was found that c8db.secrets().get() stopped working after upgrading from `1.1.25.x`. The issue was when `Request` class doesn't have `tenant` as a parameter for path then SecretProvider cannot convert service's jwt to user`s jwt because of `tenant == null`

#Solution
is to provide additional parameter `dbTenant` in `C8Executeable` class and insert it into `Request` class.
This fix also fixed workaround for `Functions`:
```
 if (tenant != null && !tenant.isEmpty() && service != Service.C8FUNCTION) {
 ```

