### PR TITLE
C84J-25: Connection pool improvement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.43-SNAPSHOT</version>
+    <version>1.1.42-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -347,7 +347,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.25</tag>
+        <tag>c84j-1.1.42</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.42</version>
+    <version>1.1.43-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -347,7 +347,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.42</tag>
+        <tag>c84j-1.1.25</tag>
     </scm>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.42-SNAPSHOT</version>
+    <version>1.1.43-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>co.macrometa</groupId>
     <artifactId>c84j</artifactId>
-    <version>1.1.42-SNAPSHOT</version>
+    <version>1.1.42</version>
     <inceptionYear>2019</inceptionYear>
     <packaging>jar</packaging>
 
@@ -347,7 +347,7 @@
         <url>https://github.com/Macrometacorp/C84j.git</url>
         <connection>scm:git:git@github.com:Macrometacorp/C84j.git</connection>
         <developerConnection>scm:git:git@github.com:Macrometacorp/C84j.git</developerConnection>
-        <tag>c84j-1.1.25</tag>
+        <tag>c84j-1.1.42</tag>
     </scm>
 
     <organization>

--- a/src/main/java/com/c8db/internal/http/HttpCommunication.java
+++ b/src/main/java/com/c8db/internal/http/HttpCommunication.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ *  Modifications copyright (c) 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal.http;
@@ -20,19 +22,20 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.SocketException;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
-import com.c8db.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.c8db.C8DBException;
+import com.c8db.Service;
 import com.c8db.internal.net.AccessType;
 import com.c8db.internal.net.C8DBRedirectException;
+import com.c8db.internal.net.Connection;
 import com.c8db.internal.net.Host;
 import com.c8db.internal.net.HostDescription;
 import com.c8db.internal.net.HostHandle;
 import com.c8db.internal.net.HostHandler;
+import com.c8db.internal.net.ManagedConnection;
 import com.c8db.internal.util.HostUtils;
 import com.c8db.internal.util.RequestUtils;
 import com.c8db.util.C8Serialization;
@@ -84,8 +87,8 @@ public class HttpCommunication implements Closeable {
         Host host = hostHandler.get(hostHandle, accessType);
         try {
             while (true) {
-                try {
-                    final HttpConnection connection = (HttpConnection) host.connection();
+                try (final ManagedConnection<Connection> managedConnection = host.connection()) {
+                    final HttpConnection connection = (HttpConnection) managedConnection.connection();
                     final Response response = connection.execute(request);
                     hostHandler.success();
                     hostHandler.confirm();

--- a/src/main/java/com/c8db/internal/net/ConnectionDisposer.java
+++ b/src/main/java/com/c8db/internal/net/ConnectionDisposer.java
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2024 Macrometa Corp All rights reserved.
+ */
+package com.c8db.internal.net;
+
+interface ConnectionDisposer {
+
+    /**
+     * Return connection back to the connection pool
+     */
+    void dispose(Connection connection);
+}

--- a/src/main/java/com/c8db/internal/net/ConnectionPool.java
+++ b/src/main/java/com/c8db/internal/net/ConnectionPool.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ *  Modifications copyright (c) 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal.net;
@@ -21,10 +23,8 @@ import java.io.Closeable;
 /**
  *
  */
-public interface ConnectionPool extends Closeable {
+public interface ConnectionPool extends Closeable, ConnectionDisposer {
 
-    Connection createConnection(final HostDescription host);
-
-    Connection connection();
+    ManagedConnection<Connection> connection();
 
 }

--- a/src/main/java/com/c8db/internal/net/ConnectionPoolImpl.java
+++ b/src/main/java/com/c8db/internal/net/ConnectionPoolImpl.java
@@ -96,6 +96,7 @@ public class ConnectionPoolImpl implements ConnectionPool {
             CompletableFuture<Connection> future;
             while ((future = waitingQueue.poll()) != null && future.isCancelled()) {};
             if (future != null) {
+            	usedConnections.add(connection);
                 future.complete(connection);
             } else {
                 // No threads waiting for connections

--- a/src/main/java/com/c8db/internal/net/Host.java
+++ b/src/main/java/com/c8db/internal/net/Host.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ *  Modifications copyright (c) 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal.net;
@@ -25,7 +27,7 @@ public interface Host {
 
     HostDescription getDescription();
 
-    Connection connection();
+    ManagedConnection<Connection> connection();
 
     void closeOnError();
 

--- a/src/main/java/com/c8db/internal/net/HostImpl.java
+++ b/src/main/java/com/c8db/internal/net/HostImpl.java
@@ -12,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ *  Modifications copyright (c) 2024 Macrometa Corp All rights reserved.
  */
 
 package com.c8db.internal.net;
@@ -46,7 +48,7 @@ public class HostImpl implements Host {
     }
 
     @Override
-    public Connection connection() {
+    public ManagedConnection<Connection> connection() {
         return connectionPool.connection();
     }
 

--- a/src/main/java/com/c8db/internal/net/ManagedConnection.java
+++ b/src/main/java/com/c8db/internal/net/ManagedConnection.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2024 Macrometa Corp All rights reserved.
+ */
+package com.c8db.internal.net;
+
+import java.io.IOException;
+
+public class ManagedConnection<C extends Connection> implements AutoCloseable {
+    
+    private C connection;
+    private ConnectionDisposer disposer;
+    
+    public ManagedConnection(C connection, ConnectionDisposer disposer) {
+        this.connection = connection;
+        this.disposer = disposer;
+    }
+    
+    public C connection() {
+        return this.connection;
+    }
+    
+    public <C2 extends C> ManagedConnection<C2> castConnection() {
+        final C2 resource = (C2) this.connection;
+        final ConnectionDisposer disposer = this.disposer;
+        this.disposer = null;
+        return new ManagedConnection<>(resource, disposer);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (disposer != null) {
+            disposer.dispose(connection);
+        }
+    }
+
+}

--- a/src/main/java/com/c8db/internal/velocystream/VstCommunication.java
+++ b/src/main/java/com/c8db/internal/velocystream/VstCommunication.java
@@ -103,10 +103,10 @@ public abstract class VstCommunication<R, C extends VstConnection> implements Cl
                     hostHandler.confirm();
                     return managedConnection;
                 } catch (final IOException e) {
-                	try {
-                		managedConnection.close();
-                	} catch (final IOException e2) {
-                		LOGGER.warn("Failed to dispose managed connection");
+                    try {
+                        managedConnection.close();
+                    } catch (final IOException e2) {
+                        LOGGER.warn("Failed to dispose managed connection");
                 	}
                     hostHandler.fail();
                     if (hostHandle != null && hostHandle.getHost() != null) {


### PR DESCRIPTION
## Issue
The current implementation caused the connections to expire before they had the chance to be reused if the requests were not frequent. This was causing high latency for Akamai EdgeKV. 


## Solution
Summarizing the changes: in the connection pool, instead of having an array of connections and cycling through the whole array as new connections are requested, the pool can have a stack of connections. Whenever a new connection is used and is no longer needed, it is returned (disposed) back to the pool and pushed onto the stack of available connections. To return connections back to the pool, the `ManagedConnection` class.
The previous implementation caused the connections to expire before they could be reused if the requests were not frequent. This was causing high latency for Akamai EdgeKV. With the new approach (stack of connections), recently used connections are the first ones to be popped out, reducing the chance of them expiring and thus reducing the need to reopen connections, which is expensive.